### PR TITLE
Add share of total support and enhanced time parsing

### DIFF
--- a/nl-poc/app/synonyms.py
+++ b/nl-poc/app/synonyms.py
@@ -42,6 +42,8 @@ def _build_dimension_aliases() -> Dict[str, str]:
         "location": "premise",
         "place": "premise",
         "weapon": "weapon",
+        "weapon category": "weapon",
+        "weapon categories": "weapon",
         "victim age": "vict_age",
         "age": "vict_age",
         "month": "month",
@@ -58,7 +60,6 @@ def _build_compare_keywords() -> Dict[str, str]:
         "mom%": "mom",
         "qoq": "mom",
         "compare to last month": "mom",
-        "last month": "mom",
         "yoy": "yoy",
         "year over year": "yoy",
         "year-over-year": "yoy",
@@ -72,6 +73,9 @@ def load_synonyms() -> SynonymBundle:
         dimension_aliases=_build_dimension_aliases(),
         compare_keywords=_build_compare_keywords(),
     )
+
+
+SHARE_TOKENS = {"share", "percentage", "% of", "percent of"}
 
 
 def find_dimension(keyword: str, bundle: SynonymBundle) -> str | None:

--- a/nl-poc/app/time_utils.py
+++ b/nl-poc/app/time_utils.py
@@ -5,7 +5,7 @@ import calendar
 import re
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-from typing import Optional, Tuple
+from typing import Optional
 
 
 @dataclass
@@ -13,8 +13,15 @@ class TimeRange:
     start: date
     end: date
     label: str
+    op: str = "between"
 
     def to_filter(self) -> dict:
+        if self.op == "=":
+            return {
+                "field": "month",
+                "op": "=",
+                "value": self.start.isoformat(),
+            }
         return {
             "field": "month",
             "op": "between",
@@ -22,7 +29,10 @@ class TimeRange:
         }
 
 
-_QUARTER_PATTERN = re.compile(r"q([1-4])\s*(\d{4})", re.IGNORECASE)
+_QUARTER_PATTERN = re.compile(
+    r"\b(?:q([1-4])\s*([12]\d{3})|([12]\d{3})\s*[-\/]?\s*q([1-4]))\b",
+    re.IGNORECASE,
+)
 _MONTH_PATTERN = re.compile(r"(20\d{2})[-/](0[1-9]|1[0-2])")
 _YEAR_PATTERN = re.compile(r"\b(20\d{2})\b")
 
@@ -46,12 +56,30 @@ def current_date() -> date:
     return date.today()
 
 
+def current_month_start(today: Optional[date] = None) -> date:
+    today = today or current_date()
+    return date(today.year, today.month, 1)
+
+
+def previous_month_start(today: Optional[date] = None) -> date:
+    start = current_month_start(today)
+    anchor = start - timedelta(days=1)
+    return date(anchor.year, anchor.month, 1)
+
+
+def _shift_month(start: date, delta: int) -> date:
+    year = start.year + ((start.month - 1 + delta) // 12)
+    month = (start.month - 1 + delta) % 12 + 1
+    return date(year, month, 1)
+
+
 def parse_relative_range(text: str, today: Optional[date] = None) -> Optional[TimeRange]:
     today = today or current_date()
     text_l = text.lower()
-    if "ytd" in text_l or "year to date" in text_l:
+    if "ytd" in text_l or "year to date" in text_l or "this year to date" in text_l:
         start = date(today.year, 1, 1)
-        return TimeRange(start=start, end=_next_month(today.replace(day=1)), label=f"{today.year} YTD")
+        end = current_month_start(today)
+        return TimeRange(start=start, end=end, label=f"{today.year} YTD")
     if "this year" in text_l:
         start = date(today.year, 1, 1)
         end = date(today.year, 12, 31)
@@ -61,12 +89,16 @@ def parse_relative_range(text: str, today: Optional[date] = None) -> Optional[Ti
         end = date(today.year - 1, 12, 31)
         return TimeRange(start=start, end=end, label=f"{today.year - 1}")
     if "this month" in text_l:
-        start = date(today.year, today.month, 1)
+        start = current_month_start(today)
         return TimeRange(start=start, end=_next_month(start), label=start.strftime("%Y-%m"))
     if "last month" in text_l:
-        anchor = today.replace(day=1) - timedelta(days=1)
-        start = date(anchor.year, anchor.month, 1)
-        return TimeRange(start=start, end=_next_month(start), label=start.strftime("%Y-%m"))
+        start = previous_month_start(today)
+        end = _next_month(start)
+        return TimeRange(start=start, end=end, label=start.strftime("%Y-%m"), op="=")
+    if "last 3 months" in text_l or "last three months" in text_l:
+        end = current_month_start(today)
+        start = _shift_month(previous_month_start(today), -2)
+        return TimeRange(start=start, end=end, label="Last 3 months")
     if "last quarter" in text_l:
         quarter = (today.month - 1) // 3
         if quarter == 0:
@@ -85,12 +117,17 @@ def parse_quarter(text: str) -> Optional[TimeRange]:
     match = _QUARTER_PATTERN.search(text)
     if not match:
         return None
-    q = int(match.group(1))
-    year = int(match.group(2))
+    if match.group(1) and match.group(2):
+        q = int(match.group(1))
+        year = int(match.group(2))
+    else:
+        year = int(match.group(3))
+        q = int(match.group(4))
     start_month = (q - 1) * 3 + 1
     start = date(year, start_month, 1)
-    end = date(year, start_month + 2, calendar.monthrange(year, start_month + 2)[1])
-    return TimeRange(start=start, end=_next_month(end.replace(day=1)), label=f"Q{q} {year}")
+    end_month = start_month + 2
+    end = date(year, end_month, 1)
+    return TimeRange(start=start, end=_next_month(end), label=f"Q{q} {year}")
 
 
 def parse_month(text: str) -> Optional[TimeRange]:
@@ -116,7 +153,7 @@ def parse_year(text: str) -> Optional[TimeRange]:
 
 def extract_time_range(text: str, today: Optional[date] = None) -> Optional[TimeRange]:
     today = today or current_date()
-    for parser in (parse_quarter, parse_month, parse_relative_range, parse_year):
+    for parser in (parse_month, parse_quarter, parse_relative_range, parse_year):
         result = parser(text)
         if result:
             return result

--- a/nl-poc/eval/questions.yaml
+++ b/nl-poc/eval/questions.yaml
@@ -1,21 +1,38 @@
 questions:
-  - "Top 10 crime types citywide in 2024-YTD; include MoM %."
-  - "Incidents by area for 2023-06; show rank and share of city total."
-  - "Hollywood: which premise types had the largest MoM increase in 2024-08?"
-  - "Central vs Hollywood: compare weapon categories in 2024-Q2."
-  - "Top 10 areas by robbery in 2024 YTD with a trend line."
-  - "What were the top 5 weapon categories last month?"
-  - "Show incidents in Downtown by premise for 2024-03."
-  - "Give me incidents by area year to date."
-  - "Which crime types rose the most month over month in 2023-12?"
-  - "Compare Hollywood and Wilshire areas for weapon usage in Q1 2024."
-  - "How many incidents citywide in 2022?"
-  - "List the bottom 5 areas by incidents in 2024-05."
-  - "What premises in Hollywood had the biggest drop MoM in 2024-07?"
-  - "Trend of burglaries by month in 2023."
-  - "Victim age distribution for 2024-Q2."
-  - "Incidents involving firearms in Central during 2024-04."
-  - "Top 10 areas for robbery this month."
-  - "Compare assaults in 2023 vs 2024 YTD."
-  - "Incidents by weapon for Venice in 2024-02; include MoM change."
-  - "Show trend of total incidents for the city over the last year."
+  - q: "Top 10 crime types citywide in 2024-YTD; include MoM %."
+  - q: "Incidents by area for 2023-06; show share of city total."
+    expect:
+      cols: ["area", "incidents", "share_city"]
+      rules:
+        - "month==2023-06-01"
+        - "share_city_sum≈1.0"
+        - "sorted:incidents:desc"
+  - q: "Hollywood: which premise types had the largest MoM increase in 2024-08?"
+  - q: "Central vs Hollywood: compare weapon categories in 2024-Q2."
+    expect:
+      cols: ["weapon", "area", "incidents"]
+      rules:
+        - "months==[2024-04-01..2024-06-01]"
+        - "areas=={Central,Hollywood}"
+  - q: "Top 10 areas by robbery in 2024 YTD with a trend line."
+  - q: "What were the top 5 weapon categories across all areas last month?"
+    expect:
+      cols: ["weapon", "incidents"]
+      rules:
+        - "limit==5"
+        - "sorted:incidents:desc"
+        - "month==<PREV_MONTH_START>"
+  - q: "Show incidents in Downtown by premise for 2024-03."
+  - q: "Give me incidents by area year to date."
+  - q: "Which crime types rose the most month over month in 2023-12?"
+  - q: "Compare Hollywood and Wilshire areas for weapon usage in Q1 2024."
+  - q: "How many incidents citywide in 2022?"
+  - q: "List the bottom 5 areas by incidents in 2024-05."
+  - q: "What premises in Hollywood had the biggest drop MoM in 2024-07?"
+  - q: "Trend of burglaries by month in 2023."
+  - q: "Victim age distribution for 2024-Q2."
+  - q: "Incidents involving firearms in Central during 2024-04."
+  - q: "Top 10 areas for robbery this month."
+  - q: "Compare assaults in 2023 vs 2024 YTD."
+  - q: "Incidents by weapon for Venice in 2024-02; include MoM change."
+  - q: "Show trend of total incidents for the city over the last year."


### PR DESCRIPTION
## Summary
- add synonyms for weapon category phrasing and share keywords to drive planner features
- enhance planner to detect share requests, quarter/relative time ranges, area comparisons, and weapon category grouping while setting appropriate limits and orderings
- update SQL builder to compute share of city total via window functions when requested and expand evaluation questions with new expectations

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dbfc3a4920832ea8f8fe7650eb9d2e