### PR TITLE
Add LLM intent planner with fallback

### DIFF
--- a/nl-poc/README.md
+++ b/nl-poc/README.md
@@ -49,6 +49,16 @@ nl-poc/
 
 `eval/questions.yaml` contains 20 representative questions for manual or automated testing.
 
+## Enabling LLM Intent Parsing
+
+By default the service uses the heuristic planner. To enable the LLM-powered intent agent:
+
+1. Copy `config/settings.example.env` to `.env` (or export the variables in your shell).
+2. Set `INTENT_USE_LLM=true` and provide `LLM_PROVIDER`, `LLM_MODEL`, and `LLM_API_KEY` values for your provider.
+3. Restart the API so the new environment variables take effect.
+
+When the LLM settings are omitted or the call fails, the service automatically falls back to the rule-based planner.
+
 ## Notes
 
 - The planner uses heuristic parsing suitable for demonstration purposes.

--- a/nl-poc/app/llm_client.py
+++ b/nl-poc/app/llm_client.py
@@ -1,0 +1,64 @@
+import os
+from datetime import date
+
+
+class LLMNotConfigured(Exception):
+    pass
+
+
+def current_month_start(today=None):
+    today = today or date.today()
+    return date(today.year, today.month, 1)
+
+
+def month_start(dt):
+    return date(dt.year, dt.month, 1)
+
+
+def _add_months(dt: date, months: int) -> date:
+    year_offset, new_month_index = divmod(dt.month - 1 + months, 12)
+    return date(dt.year + year_offset, new_month_index + 1, dt.day)
+
+
+def fill_time_tokens(prompt: str, today=None) -> str:
+    today = today or date.today()
+    cur = current_month_start(today)
+    prev = month_start(_add_months(cur, -1))
+    cur_m2 = month_start(_add_months(cur, -2))
+    return (
+        prompt.replace("<CURRENT_MONTH_START>", cur.isoformat())
+        .replace("<PREV_MONTH_START>", prev.isoformat())
+        .replace("<CURRENT_MONTH_MINUS_2>", cur_m2.isoformat())
+    )
+
+
+def call_intent_llm(prompt_text: str, semantic_yaml: str, column_catalog: list, question: str) -> str:
+    """
+    Returns raw JSON string from the LLM. Raises LLMNotConfigured if env is missing.
+    """
+    provider = os.getenv("LLM_PROVIDER", "").lower()
+    model = os.getenv("LLM_MODEL", "")
+    api_key = os.getenv("LLM_API_KEY", "")
+
+    if not provider or not model or not api_key:
+        raise LLMNotConfigured("Missing LLM_PROVIDER/LLM_MODEL/LLM_API_KEY")
+
+    # ---- Replace this block with your provider-specific call. ----
+    # Pseudocode example for OpenAI Chat Completions:
+    #
+    # from openai import OpenAI
+    # client = OpenAI(api_key=api_key)
+    # sys_prompt = fill_time_tokens(prompt_text)
+    # user_payload = f"Semantic spec:\n```yaml\n{semantic_yaml}\n```\n\nColumns:\n{column_catalog}\n\nQuestion:\n{question}"
+    # resp = client.chat.completions.create(
+    #   model=model,
+    #   messages=[{"role":"system","content": sys_prompt},
+    #             {"role":"user","content": user_payload}],
+    #   temperature=0
+    # )
+    # return resp.choices[0].message.content.strip()
+    #
+    # --------------------------------------------------------------
+
+    # For now, raise so the caller can fall back to rule-based parsing.
+    raise LLMNotConfigured("Stub: wire your provider in app/llm_client.py")

--- a/nl-poc/app/llm_prompt_intent.txt
+++ b/nl-poc/app/llm_prompt_intent.txt
@@ -1,0 +1,70 @@
+You convert a user’s natural-language question into a STRICT JSON plan for analytics over a single table in DuckDB.
+
+YOUR JOB
+1) Identify metrics, group_by dimensions, filters, time window, sort, limit, and compare flags (MoM/YoY).
+2) Use ONLY allowed metrics/dimensions from the provided semantic spec.
+3) Normalize vague time (“last month”, “Q2 2024”, “YTD”) into concrete month starts (YYYY-MM-01).
+4) RETURN ONLY JSON in the schema below. No prose.
+
+SEMANTIC SPEC (EXAMPLE)
+defaults:
+  table: la_crime_raw
+  date_grain: month
+dimensions:
+  month:        { column: "DATE OCC", type: date_month }
+  area:         { column: "AREA NAME" }
+  crime_type:   { column: "Crm Cd Desc" }
+  premise:      { column: "Premis Desc" }
+  weapon:       { column: "Weapon Desc" }
+  vict_age:     { column: "Vict Age", bucket: "int" }
+metrics:
+  incidents:
+    agg: count
+    grain: [month, area, crime_type, premise, weapon, vict_age]
+
+COLUMN CATALOG (EXAMPLE)
+"DATE OCC","AREA NAME","Crm Cd Desc","Premis Desc","Weapon Desc","Vict Age","DR_NO"
+
+ALLOWED & SYNONYMS
+- Metrics: incidents (COUNT rows)
+- Dims: month, area, crime_type, premise, weapon, vict_age
+- “crimes/cases/events/reports” → incidents
+- “district/division/precinct” → area
+- “offense/offence/category/type” → crime_type
+- “premises/location type/where” → premise
+- “gun/firearm/weapon type” → weapon
+- “age/victim age/age group” → vict_age
+COMPARE FLAGS
+- MoM / “month over month” / “vs last month” → {"type":"mom","periods":1}
+- YoY / “year over year” / “vs last year” → {"type":"yoy","periods":12}
+
+TIME NORMALIZATION
+- Operate at month grain, use first day of month: YYYY-MM-01.
+- Examples:
+  * “Q2 2024” → ["2024-04-01","2024-06-01"]
+  * “YTD 2025” → ["2025-01-01","<CURRENT_MONTH_START>"]
+  * “last month” → ["<PREV_MONTH_START>","<PREV_MONTH_START>"]
+  * “last 3 months” → ["<CURRENT_MONTH_MINUS_2>","<CURRENT_MONTH_START>"]
+- If no time mentioned, omit the month filter.
+
+OUTPUT JSON SCHEMA
+{
+  "metrics": ["incidents"],
+  "group_by": ["<dimension>", "..."],
+  "filters": [
+    {"field":"<dimension>","op":"="|"in"|"between","value":"<value or [v1,v2]>"}
+  ],
+  "order_by": [{"field":"<metric or dimension>","dir":"asc"|"desc"}],
+  "limit": <integer>,
+  "compare": {"type":"mom"|"yoy","periods": <int>} | null,
+  "notes": "<brief assumptions if any>",
+  "errors": []
+}
+
+RULES
+- Use only allowed metrics/dimensions.
+- Default limit=10 when the question implies “top/rank” and no limit given.
+- For ranges use {"field":"month","op":"between","value":["YYYY-MM-01","YYYY-MM-01"]}.
+- DO NOT correct typos; put suggestions in `errors`:
+  "Unknown area 'Hoolywood'. Try: Hollywood, West LA, Central."
+- RETURN ONLY JSON. NO SQL, NO PROSE.

--- a/nl-poc/config/settings.example.env
+++ b/nl-poc/config/settings.example.env
@@ -1,0 +1,7 @@
+# Intent engine switch (default true)
+INTENT_USE_LLM=true
+
+# LLM provider config (fill these if you want LLM intent)
+LLM_PROVIDER=openai
+LLM_MODEL=gpt-4o-mini  # or your choice
+LLM_API_KEY=sk-REPLACE_ME

--- a/nl-poc/tests/test_intent_llm.py
+++ b/nl-poc/tests/test_intent_llm.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.planner import build_plan
+
+
+def test_plan_top10_crimes_ytd():
+    q = "Top 10 crime types in Hollywood for 2024 YTD; show MoM %."
+    plan = build_plan(q, prefer_llm=False)
+    assert "incidents" in plan["metrics"]
+    assert "crime_type" in plan["group_by"]
+    assert plan.get("limit", 10) == 10
+
+
+def test_plan_single_month():
+    q = "Incidents by area for 2023-06."
+    plan = build_plan(q, prefer_llm=False)
+    months = [f for f in plan.get("filters", []) if f["field"] == "month"]
+    assert months and months[0]["op"] in ("=", "between")


### PR DESCRIPTION
## Summary
- add an LLM prompt template and stub client for filling time tokens and calling providers
- wrap the planner with an LLM-first path that falls back to the heuristic logic and surface the last engine
- expose LLM toggles through the FastAPI endpoint, document configuration, and add regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc057c02e0832eadf1d8fc3b46866d