### PR TITLE
Wire OpenAI chat completion for intent planner

### DIFF
--- a/nl-poc/README.md
+++ b/nl-poc/README.md
@@ -18,7 +18,7 @@ nl-poc/
 1. **Install dependencies**
 
    ```bash
-   pip install fastapi uvicorn duckdb pyyaml
+   pip install fastapi uvicorn duckdb pyyaml openai
    ```
 
 2. **Add data**
@@ -54,7 +54,8 @@ nl-poc/
 By default the service uses the heuristic planner. To enable the LLM-powered intent agent:
 
 1. Copy `config/settings.example.env` to `.env` (or export the variables in your shell).
-2. Set `INTENT_USE_LLM=true` and provide `LLM_PROVIDER`, `LLM_MODEL`, and `LLM_API_KEY` values for your provider.
+2. Set `INTENT_USE_LLM=true` and provide `LLM_PROVIDER`, `LLM_MODEL`, and `LLM_API_KEY` values for your provider. When using the
+   bundled OpenAI integration, `LLM_PROVIDER` must be `openai` and `pip install openai` is required in the runtime environment.
 3. Restart the API so the new environment variables take effect.
 
 When the LLM settings are omitted or the call fails, the service automatically falls back to the rule-based planner.


### PR DESCRIPTION
## Summary
- replace the LLM intent stub with a real OpenAI Chat Completions integration and runtime error handling
- document the OpenAI dependency and configuration requirements for enabling the intent agent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2314e550832eaec18a16dcf5c946