### PR TITLE
Use OpenAI Responses API for intent model

### DIFF
--- a/nl-poc/app/llm_client.py
+++ b/nl-poc/app/llm_client.py
@@ -140,22 +140,26 @@ def call_intent_llm(prompt_text: str, semantic_yaml: str, column_catalog: list, 
         logger.debug("Initializing OpenAI client for provider '%s' with model '%s'", provider, model)
         client = OpenAI(api_key=api_key)
         logger.debug(
-            "Sending OpenAI chat completion request", extra={"model": model, "column_count": len(column_catalog)}
+            "Sending OpenAI responses request", extra={"model": model, "column_count": len(column_catalog)}
         )
-        resp = client.chat.completions.create(
+        resp = client.responses.create(
             model=model,
             temperature=0,
-            messages=[
-                {"role": "system", "content": sys_prompt},
-                {"role": "user", "content": user_payload},
+            input=[
+                {"role": "system", "content": [{"type": "text", "text": sys_prompt}]},
+                {"role": "user", "content": [{"type": "text", "text": user_payload}]},
             ],
         )
-        logger.info("OpenAI chat completion succeeded", extra={"response_id": getattr(resp, "id", None)})
+        logger.info("OpenAI responses request succeeded", extra={"response_id": getattr(resp, "id", None)})
     except OpenAIError as exc:  # pragma: no cover - networked call
-        logger.exception("OpenAI chat completion raised OpenAIError")
-        raise RuntimeError("OpenAI chat completion failed") from exc
+        logger.exception("OpenAI responses request raised OpenAIError")
+        raise RuntimeError("OpenAI request failed") from exc
     except Exception as exc:  # pragma: no cover - defensive fallback
-        logger.exception("OpenAI chat completion raised unexpected exception")
-        raise RuntimeError("OpenAI chat completion failed") from exc
+        logger.exception("OpenAI responses request raised unexpected exception")
+        raise RuntimeError("OpenAI request failed") from exc
 
-    return resp.choices[0].message.content.strip()
+    try:
+        return resp.output_text.strip()
+    except AttributeError:
+        # Fall back to Chat Completions-style payloads for backward compatibility.
+        return resp.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- switch the intent LLM client to the OpenAI Responses API so newer models like gpt-4o succeed
- keep a compatibility fallback for legacy chat completion style responses

## Testing
- pytest tests/test_intent_llm.py

------
https://chatgpt.com/codex/tasks/task_e_68dc2d56bfac832eb3479c707916c7e7