### PR TITLE
Improve planner handling for trends, comparisons, and weapon filters

### DIFF
--- a/nl-poc/app/synonyms.py
+++ b/nl-poc/app/synonyms.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 @dataclass(frozen=True)
@@ -78,6 +78,29 @@ def load_synonyms() -> SynonymBundle:
 SHARE_TOKENS = {"share", "percentage", "% of", "percent of"}
 
 
+WEAPON_SYNONYM_TOKENS = {
+    "firearm",
+    "firearms",
+    "gun",
+    "guns",
+    "handgun",
+    "handguns",
+    "hand gun",
+    "rifle",
+    "rifles",
+    "shotgun",
+    "shotguns",
+}
+
+WEAPON_LIKE_PATTERNS = [
+    "%firearm%",
+    "%gun%",
+    "%hand gun%",
+    "%rifle%",
+    "%shotgun%",
+]
+
+
 def find_dimension(keyword: str, bundle: SynonymBundle) -> str | None:
     keyword_l = keyword.lower().strip()
     if keyword_l in bundle.dimension_aliases:
@@ -97,4 +120,20 @@ def detect_compare(text: str, bundle: SynonymBundle) -> str | None:
     for key, value in bundle.compare_keywords.items():
         if key in text_lower:
             return value
+    return None
+
+
+def detect_weapon_patterns(text: str) -> Optional[List[str]]:
+    text_lower = text.lower()
+    for token in WEAPON_SYNONYM_TOKENS:
+        if token in text_lower:
+            return list(WEAPON_LIKE_PATTERNS)
+    return None
+
+
+def weapon_patterns_from_value(value: str) -> Optional[List[str]]:
+    value_lower = value.lower()
+    for token in WEAPON_SYNONYM_TOKENS:
+        if token in value_lower:
+            return list(WEAPON_LIKE_PATTERNS)
     return None


### PR DESCRIPTION
## Summary
- normalize LLM and rule-based plans to enforce month trends, drop unintended groupings for compares, and expand weapon filters into LIKE patterns
- update time and resolver utilities so single-month ranges become equality filters and trailing year phrases follow the current month
- adjust SQL builder defaults for month ordering, limit removal, and LIKE-any clauses to match the normalized plans

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc36a55238832e96c68d4c0420e227