### PR TITLE
Handle past N months ranges

### DIFF
--- a/nl-poc/app/time_utils.py
+++ b/nl-poc/app/time_utils.py
@@ -80,13 +80,19 @@ def parse_relative_range(text: str, today: Optional[date] = None) -> Optional[Ti
         start = date(today.year, 1, 1)
         end = _next_month(current_month_start(today))
         return TimeRange(start=start, end=end, label=f"{today.year} YTD")
+    month_window_match = re.search(r"\b(last|past)\s+(6|9|12)\s+months?\b", text_l)
+    if month_window_match:
+        qualifier, months_str = month_window_match.groups()
+        months = int(months_str)
+        end = current_month_start(today)
+        start = _shift_month(end, -months)
+        label_prefix = "Past" if qualifier == "past" else "Last"
+        return TimeRange(start=start, end=end, label=f"{label_prefix} {months} months")
     trailing_year_phrases = (
         "last year",
         "past year",
         "over the last year",
         "over last year",
-        "last 12 months",
-        "past 12 months",
     )
     if any(phrase in text_l for phrase in trailing_year_phrases):
         anchor = current_month_start(today)

--- a/nl-poc/tests/test_time_utils.py
+++ b/nl-poc/tests/test_time_utils.py
@@ -1,0 +1,13 @@
+from datetime import date
+
+from app.time_utils import TimeRange, parse_relative_range
+
+
+def test_parse_relative_range_past_nine_months():
+    today = date(2024, 3, 15)
+    result = parse_relative_range("incidents in the past 9 months", today=today)
+
+    assert isinstance(result, TimeRange)
+    assert result.start == date(2023, 6, 1)
+    assert result.end == date(2024, 3, 1)
+    assert result.label == "Past 9 months"


### PR DESCRIPTION
## Summary
- parse relative date phrases like past/last 6, 9, and 12 months using month shifting helpers
- keep annual phrases handled separately
- add unit coverage for the past 9 months scenario

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc43e16104832e92debc2083dc64e6