### PR TITLE
Add trailing year filter for trend questions

### DIFF
--- a/nl-poc/app/time_utils.py
+++ b/nl-poc/app/time_utils.py
@@ -121,6 +121,16 @@ def parse_relative_range(text: str, today: Optional[date] = None) -> Optional[Ti
     return None
 
 
+def trailing_year_range(today: Optional[date] = None) -> TimeRange:
+    """Return a time range covering the trailing 12 months."""
+
+    today = today or current_date()
+    anchor = current_month_start(today)
+    start = _shift_month(anchor, -11)
+    end = _next_month(anchor)
+    return TimeRange(start=start, end=end, label="Last 12 months")
+
+
 def parse_quarter(text: str) -> Optional[TimeRange]:
     match = _QUARTER_PATTERN.search(text)
     if not match:


### PR DESCRIPTION
## Summary
- default trend-style questions without explicit dates to a trailing 12 month filter
- expose a helper in `time_utils` for computing the trailing year range
- cover the new trend default behavior with a unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc4416ba44832eac6a276b45b89e3e