### PR TITLE
Handle collapsed month filters in SQL builder

### DIFF
--- a/nl-poc/app/sql_builder.py
+++ b/nl-poc/app/sql_builder.py
@@ -40,9 +40,21 @@ def _build_filters(filters: List[Dict[str, object]], semantic: SemanticModel, al
         if field == "month":
             month_expr = dimension_expression("month", semantic, alias)
             if isinstance(value, (list, tuple)) and len(value) >= 2 and value[0] and value[1]:
-                clauses.append(
-                    f"{month_expr} >= DATE '{value[0]}' AND {month_expr} < DATE '{value[1]}'"
-                )
+                start, end = value[0], value[1]
+                if start == end:
+                    clauses.append(f"{month_expr} = DATE '{start}'")
+                else:
+                    try:
+                        start_dt = datetime.fromisoformat(str(start))
+                        end_dt = datetime.fromisoformat(str(end))
+                    except ValueError:
+                        start_dt = end_dt = None
+                    if start_dt and end_dt and start_dt == end_dt:
+                        clauses.append(f"{month_expr} = DATE '{start}'")
+                    else:
+                        clauses.append(
+                            f"{month_expr} >= DATE '{start}' AND {month_expr} < DATE '{end}'"
+                        )
             elif isinstance(value, (list, tuple)) and value:
                 clauses.append(f"{month_expr} = DATE '{value[0]}'")
             elif isinstance(value, str):

--- a/nl-poc/tests/test_sql_builder.py
+++ b/nl-poc/tests/test_sql_builder.py
@@ -1,0 +1,34 @@
+import sys
+import types
+
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda stream: {}
+sys.modules.setdefault("yaml", yaml_stub)
+
+duckdb_stub = types.ModuleType("duckdb")
+sys.modules.setdefault("duckdb", duckdb_stub)
+
+from app.sql_builder import _build_filters
+from app.resolver import SemanticDimension, SemanticModel
+
+
+def _semantic_model() -> SemanticModel:
+    return SemanticModel(
+        table="test",
+        date_grain="month",
+        dimensions={
+            "month": SemanticDimension(name="month", column="month"),
+        },
+        metrics={},
+    )
+
+
+def test_month_filter_collapsed_range_uses_equality():
+    semantic = _semantic_model()
+    filters = [
+        {"field": "month", "op": "between", "value": ["2024-02-01", "2024-02-01"]},
+    ]
+
+    where_clause = _build_filters(filters, semantic, alias="base")
+
+    assert where_clause == "WHERE base.month = DATE '2024-02-01'"


### PR DESCRIPTION
## Summary
- rewrite month filters whose bounds collapse to a single day into equality predicates
- add a unit test ensuring the SQL builder emits the expected clause

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc44175074832e886dcac4c52b2bd4