### PR TITLE
Enhance frontend error experience with suggestion pills

### DIFF
--- a/nl-poc/frontend/index.html
+++ b/nl-poc/frontend/index.html
@@ -50,6 +50,42 @@
         box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
         margin-top: 1.5rem;
       }
+      .error-panel {
+        display: none;
+        margin-top: 1rem;
+        padding: 1rem;
+        border-radius: 6px;
+        border: 1px solid #fca5a5;
+        background: #fee2e2;
+        color: #7f1d1d;
+      }
+      .error-panel h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+      }
+      .error-message {
+        margin: 0 0 0.75rem;
+      }
+      .suggestions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      .suggestion-pill {
+        background: #fff;
+        border: 1px solid #fca5a5;
+        border-radius: 999px;
+        color: #7f1d1d;
+        padding: 0.35rem 0.85rem;
+        cursor: pointer;
+        font-size: 0.9rem;
+        transition: background 0.2s ease, color 0.2s ease;
+      }
+      .suggestion-pill:hover {
+        background: #fca5a5;
+        color: #fff;
+      }
       pre {
         background: #111827;
         color: #f3f4f6;
@@ -87,7 +123,11 @@
           <input id="question" type="text" placeholder="Ask about crime incidents..." />
           <button id="ask-btn">Ask</button>
         </div>
-        <p id="status"></p>
+        <div id="error-panel" class="error-panel">
+          <h3>Error</h3>
+          <p id="error-message" class="error-message"></p>
+          <div id="suggestions" class="suggestions"></div>
+        </div>
       </div>
       <div class="card" id="result-card" style="display: none;">
         <h2 id="answer"></h2>
@@ -107,7 +147,9 @@
     <script>
       const askBtn = document.getElementById('ask-btn');
       const questionInput = document.getElementById('question');
-      const statusEl = document.getElementById('status');
+      const errorPanel = document.getElementById('error-panel');
+      const errorMessageEl = document.getElementById('error-message');
+      const suggestionsContainer = document.getElementById('suggestions');
       const answerEl = document.getElementById('answer');
       const resultCard = document.getElementById('result-card');
       const sqlEl = document.getElementById('sql');
@@ -118,14 +160,25 @@
       let chartContext = chartCanvas.getContext('2d');
       const apiBase = window.location.port === '3000' ? 'http://127.0.0.1:8000' : window.location.origin;
 
-      askBtn.addEventListener('click', async () => {
-        const question = questionInput.value.trim();
+      askBtn.addEventListener('click', () => submitQuestion(questionInput.value));
+      questionInput.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+          submitQuestion(questionInput.value);
+        }
+      });
+
+      async function submitQuestion(rawQuestion) {
+        const question = rawQuestion.trim();
         if (!question) {
-          statusEl.textContent = 'Please enter a question.';
+          showErrorPanel('Please enter a question.');
           return;
         }
+
+        hideErrorPanel();
+        const originalButtonText = askBtn.textContent;
         askBtn.disabled = true;
-        statusEl.textContent = 'Thinking...';
+        askBtn.textContent = 'Thinking...';
+
         try {
           const response = await fetch(`${apiBase}/ask`, {
             method: 'POST',
@@ -133,18 +186,60 @@
             body: JSON.stringify({ question })
           });
           if (!response.ok) {
-            const error = await response.json();
-            throw new Error(error.detail?.message || error.detail || 'Request failed');
+            let errorDetail = {};
+            try {
+              errorDetail = await response.json();
+            } catch (parseErr) {
+              // ignore JSON parse errors and fallback to generic message
+            }
+            const detail = errorDetail?.detail ?? errorDetail;
+            const message = typeof detail === 'string' ? detail : detail?.message || 'Request failed';
+            const suggestions = Array.isArray(detail?.suggestions) ? detail.suggestions : [];
+            const err = new Error(message);
+            err.suggestions = suggestions;
+            throw err;
           }
           const data = await response.json();
           renderResult(data);
-          statusEl.textContent = '';
         } catch (err) {
-          statusEl.textContent = err.message;
+          const message = err?.message || 'Something went wrong';
+          const suggestions = Array.isArray(err?.suggestions) ? err.suggestions : [];
+          showErrorPanel(message, suggestions);
         } finally {
           askBtn.disabled = false;
+          askBtn.textContent = originalButtonText;
         }
-      });
+      }
+
+      function hideErrorPanel() {
+        errorPanel.style.display = 'none';
+        errorMessageEl.textContent = '';
+        suggestionsContainer.innerHTML = '';
+      }
+
+      function showErrorPanel(message, suggestions = []) {
+        errorMessageEl.textContent = message;
+        suggestionsContainer.innerHTML = '';
+
+        if (suggestions.length) {
+          suggestions.forEach(suggestion => {
+            const button = document.createElement('button');
+            button.className = 'suggestion-pill';
+            button.type = 'button';
+            button.textContent = suggestion;
+            button.addEventListener('click', () => {
+              questionInput.value = suggestion;
+              submitQuestion(suggestion);
+            });
+            suggestionsContainer.appendChild(button);
+          });
+          suggestionsContainer.style.display = 'flex';
+        } else {
+          suggestionsContainer.style.display = 'none';
+        }
+
+        errorPanel.style.display = 'block';
+      }
 
       function renderResult(data) {
         resultCard.style.display = 'block';


### PR DESCRIPTION
## Summary
- replace the status paragraph with a styled error panel that surfaces backend error messages and suggestions
- automatically retry a query when a suggestion pill is clicked by updating the question input and resubmitting
- add CSS so the error panel and pill buttons align with the existing card styling

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc583310f0832e9f99884aa425b127