### PR TITLE
Expose ask API execution metadata

### DIFF
--- a/nl-poc/README.md
+++ b/nl-poc/README.md
@@ -38,7 +38,7 @@ nl-poc/
 ## API Endpoints
 
 - `GET /health` – returns service status.
-- `POST /ask` – accepts `{ "question": "..." }` and returns the analysis payload including SQL, plan, narrative, table, chart spec, and lineage.
+- `POST /ask` – accepts `{ "question": "..." }` and returns the analysis payload including SQL, plan, narrative, table, chart spec, lineage, and execution metadata (`engine`, `runtime_ms`, `rowcount`).
 - `GET /explain_last` – debugging endpoint returning the last executed plan and SQL.
 
 ## Semantic Configuration

--- a/nl-poc/app/main.py
+++ b/nl-poc/app/main.py
@@ -208,6 +208,9 @@ def ask(payload: AskRequest) -> Dict[str, Any]:
         "chart": chart,
         "sql": sql,
         "plan": resolved_plan,
+        "engine": intent_engine,
+        "runtime_ms": result.runtime_ms,
+        "rowcount": result.rowcount,
         "lineage": {
             "metric_defs": metric_defs,
             "time_window": resolved_plan.get("time_window_label", "All time"),
@@ -216,7 +219,6 @@ def ask(payload: AskRequest) -> Dict[str, Any]:
             "runtime_ms": result.runtime_ms,
         },
     }
-    response["intent_engine"] = intent_engine
     _state["last_debug"] = {
         "plan": resolved_plan,
         "sql": sql,

--- a/nl-poc/app/time_utils.py
+++ b/nl-poc/app/time_utils.py
@@ -92,9 +92,17 @@ def parse_relative_range(text: str, today: Optional[date] = None) -> Optional[Ti
     if month_window_match:
         qualifier, months_str = month_window_match.groups()
         months = int(months_str)
-        end = current_month_start(today)
-        start = _shift_month(end, -months)
-        label_prefix = "Past" if qualifier == "past" else "Last"
+        anchor = current_month_start(today)
+        if qualifier == "past":
+            end = anchor
+            if today == _end_of_month(today.year, today.month):
+                end = _next_month(anchor)
+            start = _shift_month(end, -months)
+            label_prefix = "Past"
+        else:
+            end = anchor
+            start = _shift_month(end, -months)
+            label_prefix = "Last"
         return TimeRange(start=start, end=end, label=f"{label_prefix} {months} months")
     trailing_year_phrases = (
         "last year",

--- a/nl-poc/tests/test_api_response_metadata.py
+++ b/nl-poc/tests/test_api_response_metadata.py
@@ -1,0 +1,138 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+if "duckdb" not in sys.modules:
+    duckdb_stub = ModuleType("duckdb")
+    duckdb_stub.connect = lambda path: None
+    duckdb_stub.DuckDBPyConnection = object
+    duckdb_stub.Error = Exception
+    sys.modules["duckdb"] = duckdb_stub
+
+if "fastapi" not in sys.modules:
+    fastapi_stub = ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail):  # pragma: no cover - behaviour trivial
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class FastAPI:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def add_middleware(self, *args, **kwargs):  # pragma: no cover - behaviour trivial
+            return None
+
+        def on_event(self, event):  # pragma: no cover - behaviour trivial
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def get(self, path):  # pragma: no cover - behaviour trivial
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def post(self, path):  # pragma: no cover - behaviour trivial
+            def decorator(func):
+                return func
+
+            return decorator
+
+    fastapi_stub.FastAPI = FastAPI
+    fastapi_stub.HTTPException = HTTPException
+    sys.modules["fastapi"] = fastapi_stub
+
+    middleware_module = ModuleType("fastapi.middleware")
+    cors_module = ModuleType("fastapi.middleware.cors")
+
+    class CORSMiddleware:  # pragma: no cover - behaviour trivial
+        def __init__(self, *args, **kwargs):
+            pass
+
+    cors_module.CORSMiddleware = CORSMiddleware
+    middleware_module.cors = cors_module
+    sys.modules["fastapi.middleware"] = middleware_module
+    sys.modules["fastapi.middleware.cors"] = cors_module
+
+if "pydantic" not in sys.modules:
+    pydantic_stub = ModuleType("pydantic")
+
+    class BaseModel:  # pragma: no cover - behaviour trivial
+        def __init__(self, **data):
+            for key, value in data.items():
+                setattr(self, key, value)
+
+    pydantic_stub.BaseModel = BaseModel
+    sys.modules["pydantic"] = pydantic_stub
+
+if "yaml" not in sys.modules:
+    yaml_stub = ModuleType("yaml")
+    yaml_stub.safe_load = lambda stream: {}
+    sys.modules["yaml"] = yaml_stub
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.executor import QueryResult
+from app.main import AskRequest, _state, ask
+
+
+class _ExecutorStub:
+    def __init__(self, records, runtime_ms, rowcount):
+        self._result = QueryResult(records=records, runtime_ms=runtime_ms, rowcount=rowcount)
+        self.queries = []
+
+    def query(self, sql):  # pragma: no cover - exercised in tests
+        self.queries.append(sql)
+        return self._result
+
+
+class _ResolverStub:
+    def resolve(self, plan):  # pragma: no cover - exercised in tests
+        return {"metrics": ["incidents"], "filters": [], "time_window_label": "All time"}
+
+
+class _MetricStub:
+    def sql_expression(self):  # pragma: no cover - exercised in tests
+        return "COUNT(*)"
+
+
+@pytest.fixture(autouse=True)
+def restore_state():
+    original = _state.copy()
+    try:
+        yield
+    finally:
+        _state.clear()
+        _state.update(original)
+
+
+def test_ask_includes_execution_metadata(monkeypatch):
+    monkeypatch.setattr("app.main.build_plan", lambda question, prefer_llm: {"question": question})
+    monkeypatch.setattr("app.main.get_last_intent_engine", lambda: "heuristic")
+    monkeypatch.setattr("app.main.guardrails.enforce", lambda sql, resolved_plan: None)
+    monkeypatch.setattr("app.main.sql_builder.build", lambda resolved_plan, semantic: "SELECT 1")
+    monkeypatch.setattr("app.main.viz.choose_chart", lambda resolved_plan, records: {"type": "bar", "data": []})
+    monkeypatch.setattr("app.main.viz.build_narrative", lambda resolved_plan, records: "Narrative")
+
+    executor = _ExecutorStub(records=[{"value": 1}], runtime_ms=12.5, rowcount=1)
+    semantic = SimpleNamespace(metrics={"incidents": _MetricStub()})
+
+    monkeypatch.setitem(_state, "executor", executor)
+    monkeypatch.setitem(_state, "semantic", semantic)
+    monkeypatch.setitem(_state, "resolver", _ResolverStub())
+    monkeypatch.setitem(_state, "source_csv", "demo.csv")
+
+    response = ask(AskRequest(question="How many incidents?"))
+
+    assert response["engine"] == "heuristic"
+    assert response["runtime_ms"] == pytest.approx(12.5)
+    assert response["rowcount"] == 1
+    assert response["lineage"]["runtime_ms"] == pytest.approx(12.5)
+    assert "intent_engine" not in response


### PR DESCRIPTION
## Summary
- add execution metadata (engine, runtime_ms, rowcount) to the /ask payload and refresh the README contract
- ensure month window parsing keeps expected Chicago boundaries for "past" queries at month end
- cover the new response contract with a FastAPI stub unit test

## Testing
- pytest nl-poc/tests

------
https://chatgpt.com/codex/tasks/task_e_68dc5827bc50832ebff9d530f8792845