### PR TITLE
Fix chart layout sizing and update reuse

### DIFF
--- a/nl-poc/frontend/index.html
+++ b/nl-poc/frontend/index.html
@@ -74,6 +74,7 @@
         padding: 0.25rem 0.75rem;
         font-size: 0.85rem;
         font-weight: 600;
+      }
 
       .error-panel {
         display: none;
@@ -97,6 +98,7 @@
         flex-wrap: wrap;
         gap: 0.5rem;
       }
+
       .suggestion-pill {
         background: #fff;
         border: 1px solid #fca5a5;
@@ -110,8 +112,8 @@
       .suggestion-pill:hover {
         background: #fca5a5;
         color: #fff;
-
       }
+
       pre {
         background: #111827;
         color: #f3f4f6;
@@ -132,10 +134,17 @@
       .collapsible {
         margin-top: 1rem;
       }
-      canvas {
+      .chart-wrapper {
         width: 100%;
-        max-width: 600px;
-        height: 320px;
+        box-sizing: border-box;
+        height: 460px;
+        max-width: 720px;
+      }
+      .chart-wrapper canvas {
+        width: 100%;
+        height: 100%;
+        box-sizing: border-box;
+        display: block;
       }
     </style>
   </head>
@@ -160,7 +169,9 @@
           <h2 id="answer"></h2>
           <div class="result-meta" id="result-meta" aria-live="polite"></div>
         </div>
-        <canvas id="chart"></canvas>
+        <div class="chart-wrapper">
+          <canvas id="chart"></canvas>
+        </div>
         <div id="table-container"></div>
         <details class="collapsible">
           <summary>How I computed this</summary>
@@ -189,8 +200,6 @@
       const chartCanvas = document.getElementById('chart');
 
       const resultMeta = document.getElementById('result-meta');
-      let chartContext = chartCanvas.getContext('2d');
-
       let chartInstance;
 
       const apiBase = window.location.port === '3000' ? 'http://127.0.0.1:8000' : window.location.origin;
@@ -341,12 +350,11 @@
       }
 
       function renderChart(chart) {
-        if (chartInstance) {
-          chartInstance.destroy();
-          chartInstance = null;
-        }
-
         if (!chart || !chart.data || !chart.data.length) {
+          if (chartInstance) {
+            chartInstance.destroy();
+            chartInstance = null;
+          }
           const context = chartCanvas.getContext('2d');
           if (context) {
             context.clearRect(0, 0, chartCanvas.width, chartCanvas.height);
@@ -391,7 +399,7 @@
               borderSkipped: false
             };
 
-        chartInstance = new Chart(chartCanvas, {
+        const chartConfig = {
           type: chart.type || 'bar',
           data: {
             labels,
@@ -410,7 +418,21 @@
               }
             }
           }
-        });
+        };
+
+        if (chartInstance) {
+          if (chartInstance.config.type !== chartConfig.type) {
+            chartInstance.destroy();
+            chartInstance = new Chart(chartCanvas, chartConfig);
+          } else {
+            chartInstance.data.labels = labels;
+            chartInstance.data.datasets = [datasetConfig];
+            chartInstance.options = chartConfig.options;
+            chartInstance.update();
+          }
+        } else {
+          chartInstance = new Chart(chartCanvas, chartConfig);
+        }
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- wrap the chart canvas in a fixed-height container so Chart.js respects bounded sizing
- update chart rendering to reuse the existing instance and reset cleanly when data changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc602e6840832e95e716badda6008e