### PR TITLE
Add NQL validator, compiler, and tests

### DIFF
--- a/nl-poc/app/main.py
+++ b/nl-poc/app/main.py
@@ -1,6 +1,7 @@
 """FastAPI entrypoint for the NL analytics proof-of-concept."""
 from __future__ import annotations
 
+import json
 import os
 import re
 from pathlib import Path
@@ -224,6 +225,16 @@ def ask(payload: AskRequest) -> Dict[str, Any]:
     records = _format_change_pct(records)
     chart = viz.choose_chart(resolved_plan, records)
     narrative = viz.build_narrative(resolved_plan, records)
+
+    plan_metadata = {
+        "utterance": question,
+        "nql": plan.get("_nql"),
+        "critic_pass": plan.get("_critic_pass", []),
+        "engine": intent_engine,
+        "runtime_ms": result.runtime_ms,
+        "rowcount": result.rowcount,
+    }
+    llm_logger.info("telemetry=%s", json.dumps(plan_metadata, default=str))
 
     # Check for rowcap warning
     warnings: list[str] = []

--- a/nl-poc/app/nql/__init__.py
+++ b/nl-poc/app/nql/__init__.py
@@ -1,0 +1,47 @@
+"""NQL parsing, validation, and compilation utilities."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Optional
+
+from .model import NQLQuery
+from .validator import NQLValidationError, validate_nql
+from .compiler import compile_nql_query
+
+
+@dataclass
+class CompiledNQL:
+    """Container for an NQL compilation result."""
+
+    plan: Dict[str, Any]
+    nql: NQLQuery
+
+
+def is_enabled() -> bool:
+    """Return True if the NQL pipeline is enabled via environment flag."""
+
+    return os.getenv("USE_NQL", "true").lower() in {"1", "true", "yes", "on"}
+
+
+def compile_payload(payload: Dict[str, Any], today: Optional[date] = None) -> CompiledNQL:
+    """Validate and compile a raw payload dictionary into a planner plan."""
+
+    try:
+        nql = NQLQuery.parse_obj(payload)
+    except Exception as exc:  # pragma: no cover - defensive guard around validation errors
+        raise NQLValidationError(str(exc)) from exc
+
+    validated = validate_nql(nql)
+    plan = compile_nql_query(validated, today=today)
+    return CompiledNQL(plan=plan, nql=validated)
+
+
+__all__ = [
+    "CompiledNQL",
+    "NQLQuery",
+    "NQLValidationError",
+    "compile_payload",
+    "is_enabled",
+]

--- a/nl-poc/app/nql/compiler.py
+++ b/nl-poc/app/nql/compiler.py
@@ -1,0 +1,124 @@
+"""Compilation utilities for converting NQL into planner plans."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional
+
+from .model import NQLQuery
+
+
+def _current_month_start(today: Optional[date] = None) -> date:
+    anchor = today or date.today()
+    return date(anchor.year, anchor.month, 1)
+
+
+def _shift_month(anchor: date, delta: int) -> date:
+    year = anchor.year + ((anchor.month - 1 + delta) // 12)
+    month = (anchor.month - 1 + delta) % 12 + 1
+    return date(year, month, 1)
+
+
+def _parse_date(raw: Optional[str], fallback_label: str) -> date:
+    if not raw:
+        raise ValueError(f"{fallback_label} must be provided")
+    return datetime.fromisoformat(raw).date()
+
+
+def _compile_time_filter(nql: NQLQuery, today: Optional[date]) -> Dict[str, Any]:
+    window = nql.time.window
+    time_field = "month"
+    if window.type == "single_month":
+        start = _parse_date(window.start, "single_month.start")
+        return {"field": time_field, "op": "=", "value": start.isoformat()}
+    if window.type == "quarter":
+        start = _parse_date(window.start, "quarter.start")
+        end = _parse_date(window.end, "quarter.end")
+        return {"field": time_field, "op": "between", "value": [start.isoformat(), end.isoformat()]}
+    if window.type == "absolute":
+        start = _parse_date(window.start, "absolute.start")
+        if window.end:
+            end = _parse_date(window.end, "absolute.end")
+            return {"field": time_field, "op": "between", "value": [start.isoformat(), end.isoformat()]}
+        return {"field": time_field, "op": ">=", "value": start.isoformat()}
+    if window.type == "relative_months":
+        end = _current_month_start(today)
+        if window.end:
+            end = _parse_date(window.end, "relative_months.end")
+        months = window.n or 12
+        start = _shift_month(end, -months)
+        return {"field": time_field, "op": "between", "value": [start.isoformat(), end.isoformat()]}
+    if window.type == "ytd":
+        if window.end:
+            end = _parse_date(window.end, "ytd.end")
+        else:
+            end = _shift_month(_current_month_start(today), 1)
+        if window.start:
+            start = _parse_date(window.start, "ytd.start")
+        else:
+            start = date(end.year if end.month > 1 else end.year - 1, 1, 1)
+        return {"field": time_field, "op": "between", "value": [start.isoformat(), end.isoformat()]}
+    raise ValueError(f"Unsupported time window type: {window.type}")
+
+
+def _compile_filters(nql: NQLQuery, today: Optional[date]) -> List[Dict[str, Any]]:
+    compiled: List[Dict[str, Any]] = []
+    for filt in nql.filters:
+        if filt.field == "month":
+            continue
+        compiled.append({"field": filt.field, "op": filt.op, "value": filt.value})
+    compiled.append(_compile_time_filter(nql, today))
+    return compiled
+
+
+def _compile_group_by(nql: NQLQuery) -> List[str]:
+    ordered: List[str] = []
+    seen = set()
+    for dim in [*nql.group_by, *nql.dimensions]:
+        if not dim or dim in seen:
+            continue
+        ordered.append(dim)
+        seen.add(dim)
+    return ordered
+
+
+def _compile_sort(nql: NQLQuery) -> List[Dict[str, str]]:
+    order_by = [{"field": entry.by, "dir": entry.dir} for entry in nql.sort]
+    if not order_by and nql.intent == "trend":
+        order_by = [{"field": "month", "dir": "asc"}]
+    return order_by
+
+
+def _compile_compare(nql: NQLQuery) -> Optional[Dict[str, Any]]:
+    if not nql.compare:
+        return None
+    periods = 1
+    if nql.compare.type == "yoy":
+        periods = 12
+    compare = {"type": nql.compare.type, "periods": periods}
+    if nql.compare.baseline:
+        compare["baseline"] = nql.compare.baseline
+    return compare
+
+
+def compile_nql_query(nql: NQLQuery, today: Optional[date] = None) -> Dict[str, Any]:
+    """Compile an NQL query into the existing planner plan structure."""
+
+    plan: Dict[str, Any] = {
+        "metrics": [metric.alias for metric in nql.metrics],
+        "group_by": _compile_group_by(nql),
+        "filters": _compile_filters(nql, today),
+        "order_by": _compile_sort(nql),
+        "limit": nql.limit,
+    }
+    compare = _compile_compare(nql)
+    if compare:
+        plan["compare"] = compare
+    extras: Dict[str, Any] = {
+        "rowcap_hint": nql.flags.rowcap_hint,
+        "nql_compiled": True,
+        "critic_pass": nql.provenance.critic_pass,
+    }
+    plan["extras"] = extras
+    plan["_nql"] = nql.dict()
+    plan["_critic_pass"] = nql.provenance.critic_pass
+    return plan

--- a/nl-poc/app/nql/model.py
+++ b/nl-poc/app/nql/model.py
@@ -1,0 +1,229 @@
+"""Typed models for NQL v0.1."""
+from __future__ import annotations
+
+from typing import List, Literal, Optional, get_args, get_origin
+
+try:  # pragma: no cover - exercised in environments with Pydantic installed
+    from pydantic import BaseModel, Field  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for lightweight test envs
+    import copy as _copy
+    from typing import get_type_hints
+
+    class _FieldInfo:
+        def __init__(self, default=None, default_factory=None):
+            self.default = default
+            self.default_factory = default_factory
+
+    def Field(default=None, default_factory=None, **_kwargs):  # type: ignore
+        if default_factory is not None:
+            return _FieldInfo(default=None, default_factory=default_factory)
+        return _FieldInfo(default=default)
+
+    _UNSET = object()
+
+    class BaseModel:  # type: ignore
+        class Config:
+            extra = "ignore"
+
+        def __init__(self, **data):
+            annotations = get_type_hints(self.__class__)
+            setattr(self.__class__, "__nql_fields__", list(annotations.keys()))
+            extras = {k: v for k, v in data.items() if k not in annotations}
+            if extras and getattr(self.Config, "extra", "ignore") == "forbid":
+                unknown = ", ".join(sorted(extras))
+                raise ValueError(f"Unknown field(s): {unknown}")
+            for name, annotation in annotations.items():
+                if name in data:
+                    raw_value = data[name]
+                else:
+                    attr = getattr(self.__class__, name, _UNSET)
+                    if isinstance(attr, _FieldInfo):
+                        if attr.default_factory is not None:
+                            raw_value = attr.default_factory()
+                        else:
+                            raw_value = attr.default
+                    elif attr is _UNSET:
+                        raw_value = None
+                    else:
+                        raw_value = _copy.deepcopy(attr)
+                value = self._convert(annotation, raw_value)
+                setattr(self, name, value)
+
+        @classmethod
+        def _convert(cls, annotation, value):
+            if value is None:
+                return None
+            origin = get_origin(annotation)
+            if origin is Literal:
+                choices = get_args(annotation)
+                if value not in choices:
+                    raise ValueError(f"Value '{value}' not permitted; expected one of {choices}")
+                return value
+            if origin in (list, List):
+                (item_type,) = get_args(annotation)
+                return [cls._convert(item_type, item) for item in value]
+            if origin is Optional:
+                (inner,) = get_args(annotation)
+                return cls._convert(inner, value)
+            if origin is not None and str(origin).endswith("Union"):
+                args = [arg for arg in get_args(annotation) if arg is not type(None)]
+                if not args:
+                    return value
+                return cls._convert(args[0], value)
+            if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+                if isinstance(value, annotation):
+                    return value
+                if isinstance(value, dict):
+                    return annotation.parse_obj(value)
+            return value
+
+        @classmethod
+        def parse_obj(cls, obj):
+            if isinstance(obj, cls):
+                return obj
+            if not isinstance(obj, dict):
+                raise TypeError("parse_obj expects a dict payload")
+            return cls(**obj)
+
+        def copy(self, deep: bool = False):
+            if deep:
+                return _copy.deepcopy(self)
+            return self.__class__(**self.dict())
+
+        def dict(self):
+            payload = {}
+            field_names = getattr(self.__class__, "__nql_fields__", [])
+            if not field_names:
+                field_names = list(get_type_hints(self.__class__).keys())
+            for name in field_names:
+                value = getattr(self, name)
+                if isinstance(value, BaseModel):
+                    payload[name] = value.dict()
+                elif isinstance(value, list):
+                    items = []
+                    for item in value:
+                        if isinstance(item, BaseModel):
+                            items.append(item.dict())
+                        else:
+                            items.append(item)
+                    payload[name] = items
+                else:
+                    payload[name] = value
+            return payload
+
+
+IntentType = Literal["aggregate", "detail", "trend", "compare", "rank", "distribution"]
+MetricAgg = Literal["count", "sum", "avg", "min", "max", "distinct_count"]
+FilterOp = Literal["=", "!=", ">", ">=", "<", "<=", "between", "in", "not_in", "like", "like_any", "ilike", "regex"]
+FilterType = Literal["text", "text_raw", "number", "date", "category"]
+TimeGrain = Literal["day", "week", "month", "quarter", "year"]
+WindowType = Literal["single_month", "absolute", "quarter", "relative_months", "ytd"]
+CompareType = Literal["mom", "yoy", "wow", "dod"]
+CompareBaseline = Literal["previous_period", "same_period_last_year"]
+SortDirection = Literal["asc", "desc"]
+
+
+class Metric(BaseModel):
+    name: str
+    agg: MetricAgg
+    alias: str
+
+    class Config:
+        extra = "forbid"
+
+
+class Filter(BaseModel):
+    field: str
+    op: FilterOp
+    value: object
+    type: FilterType
+    notes: Optional[str] = None
+
+    class Config:
+        extra = "forbid"
+
+
+class TimeWindow(BaseModel):
+    type: WindowType
+    start: Optional[str] = None
+    end: Optional[str] = None
+    exclusive_end: bool = False
+    n: Optional[int] = Field(default=None, ge=1)
+
+    class Config:
+        extra = "forbid"
+
+
+class TimeSpec(BaseModel):
+    grain: TimeGrain
+    window: TimeWindow
+    tz: str = "America/Chicago"
+
+    class Config:
+        extra = "forbid"
+
+
+class CompareInternalWindow(BaseModel):
+    expand_prior: bool = False
+
+    class Config:
+        extra = "forbid"
+
+
+class CompareSpec(BaseModel):
+    type: CompareType
+    baseline: Optional[CompareBaseline] = None
+    internal_window: Optional[CompareInternalWindow] = None
+
+    class Config:
+        extra = "forbid"
+
+
+class Flags(BaseModel):
+    trend: Optional[bool] = None
+    strict_json: bool = True
+    require_grouping_for_trend: bool = True
+    like_passthrough: bool = True
+    single_month_equals: bool = True
+    quarter_exclusive_end: bool = True
+    rowcap_hint: int = 10_000
+
+    class Config:
+        extra = "forbid"
+
+
+class Provenance(BaseModel):
+    utterance: Optional[str] = None
+    retrieval_notes: List[str] = Field(default_factory=list)
+    confidence: Optional[float] = Field(default=None, ge=0, le=1)
+    critic_pass: List[str] = Field(default_factory=list)
+
+    class Config:
+        extra = "forbid"
+
+
+class SortSpec(BaseModel):
+    by: str
+    dir: SortDirection
+
+    class Config:
+        extra = "forbid"
+
+
+class NQLQuery(BaseModel):
+    nql_version: Literal["0.1"]
+    intent: IntentType
+    dataset: str
+    metrics: List[Metric]
+    time: TimeSpec
+    dimensions: List[str] = Field(default_factory=list)
+    filters: List[Filter] = Field(default_factory=list)
+    compare: Optional[CompareSpec] = None
+    group_by: List[str] = Field(default_factory=list)
+    sort: List[SortSpec] = Field(default_factory=list)
+    limit: int = Field(default=100, ge=1)
+    flags: Flags = Field(default_factory=Flags)
+    provenance: Provenance = Field(default_factory=Provenance)
+
+    class Config:
+        extra = "forbid"

--- a/nl-poc/app/nql/validator.py
+++ b/nl-poc/app/nql/validator.py
@@ -1,0 +1,146 @@
+"""Validator for NQL v0.1 payloads."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Iterable, List, Optional, Set
+
+from .model import NQLQuery
+
+
+SERVER_MAX_LIMIT = 2000
+
+
+class NQLValidationError(ValueError):
+    """Raised when an NQL payload fails critic validation."""
+
+
+def _parse_date(raw: Optional[str], context: str) -> date:
+    if not raw:
+        raise NQLValidationError(f"{context} must be provided")
+    try:
+        return datetime.fromisoformat(raw).date()
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise NQLValidationError(f"{context} must be an ISO date: {raw}") from exc
+
+
+def _first_day_of_month(dt: date) -> date:
+    return date(dt.year, dt.month, 1)
+
+
+def _next_month(dt: date) -> date:
+    if dt.month == 12:
+        return date(dt.year + 1, 1, 1)
+    return date(dt.year, dt.month + 1, 1)
+
+
+def _next_quarter_start(dt: date) -> date:
+    quarter = (dt.month - 1) // 3
+    next_quarter = (quarter + 1) % 4
+    year = dt.year + (1 if quarter == 3 else 0)
+    month = next_quarter * 3 + 1
+    return date(year, month, 1)
+
+
+def _ensure_single_month_filter(nql: NQLQuery, critic_pass: List[str]) -> None:
+    if nql.time.window.type != "single_month" or not nql.flags.single_month_equals:
+        return
+    start = _parse_date(nql.time.window.start, "single_month.start")
+    if start != _first_day_of_month(start):
+        raise NQLValidationError("single_month start must be first day of month")
+    target_value = start.isoformat()
+    matching = [f for f in nql.filters if f.field == "month" and f.op == "="]
+    if not matching:
+        raise NQLValidationError("single_month queries must include an equality filter on month")
+    if not any(str(f.value) == target_value for f in matching):
+        raise NQLValidationError("month equality filter must match the requested single month")
+    critic_pass.append("single_month_equality")
+
+
+def _ensure_quarter_bounds(nql: NQLQuery, critic_pass: List[str]) -> None:
+    if nql.time.window.type != "quarter" or not nql.flags.quarter_exclusive_end:
+        return
+    start = _parse_date(nql.time.window.start, "quarter.start")
+    end = _parse_date(nql.time.window.end, "quarter.end")
+    expected = _next_quarter_start(start)
+    if end != expected:
+        raise NQLValidationError("quarter window end must be first day of next quarter")
+    if not nql.time.window.exclusive_end:
+        nql.time.window.exclusive_end = True
+    critic_pass.append("quarter_exclusive_end")
+
+
+def _ensure_trend_grouping(nql: NQLQuery, critic_pass: List[str]) -> None:
+    if nql.intent != "trend" or not nql.flags.require_grouping_for_trend:
+        return
+    time_dim = "month"
+    present = set(nql.group_by) | set(nql.dimensions)
+    if time_dim not in present:
+        nql.group_by.insert(0, time_dim)
+    if nql.time.window.type == "relative_months" and nql.time.window.n is None:
+        nql.time.window.n = 12
+    critic_pass.append("trend_grouping")
+
+
+def _ensure_mom_expand_prior(nql: NQLQuery, critic_pass: List[str]) -> None:
+    compare = nql.compare
+    if not compare or compare.type != "mom" or nql.time.window.type != "single_month":
+        return
+    if compare.internal_window is None:
+        from .model import CompareInternalWindow
+
+        compare.internal_window = CompareInternalWindow(expand_prior=True)
+    else:
+        compare.internal_window.expand_prior = True
+    critic_pass.append("mom_single_month_expand_prior")
+
+
+def _validate_like_filters(nql: NQLQuery, critic_pass: List[str]) -> None:
+    pattern_ops = {"like", "ilike", "like_any"}
+    for filt in nql.filters:
+        if filt.op not in pattern_ops:
+            continue
+        if filt.type != "text_raw":
+            raise NQLValidationError("LIKE filters must use type=text_raw for passthrough")
+    critic_pass.append("like_passthrough")
+
+
+def _validate_sort(nql: NQLQuery, critic_pass: List[str]) -> None:
+    if not nql.sort:
+        return
+    metric_aliases = {metric.alias for metric in nql.metrics}
+    dimension_names: Set[str] = set(nql.dimensions) | set(nql.group_by)
+    dimension_names.add("month")
+    for sort in nql.sort:
+        if sort.by not in metric_aliases and sort.by not in dimension_names:
+            raise NQLValidationError(f"Sort target '{sort.by}' must be a metric alias or dimension")
+    critic_pass.append("sort_safety")
+
+
+def _clamp_limit(nql: NQLQuery, critic_pass: List[str]) -> None:
+    rowcap_hint = min(max(1, nql.flags.rowcap_hint), SERVER_MAX_LIMIT)
+    nql.flags.rowcap_hint = rowcap_hint
+    nql.limit = min(max(1, nql.limit), rowcap_hint, SERVER_MAX_LIMIT)
+    critic_pass.append("limit_clamp")
+
+
+def validate_nql(nql: NQLQuery) -> NQLQuery:
+    """Run critic validations and return a possibly-normalised copy."""
+
+    working = nql.copy(deep=True)
+    if not working.metrics:
+        raise NQLValidationError("metrics must contain at least one entry")
+    critic_pass: List[str] = []
+
+    _ensure_single_month_filter(working, critic_pass)
+    _ensure_quarter_bounds(working, critic_pass)
+    _ensure_trend_grouping(working, critic_pass)
+    _ensure_mom_expand_prior(working, critic_pass)
+    _validate_like_filters(working, critic_pass)
+    _validate_sort(working, critic_pass)
+    _clamp_limit(working, critic_pass)
+
+    provenance = working.provenance
+    seen: Iterable[str] = provenance.critic_pass
+    merged = list(dict.fromkeys([*seen, *critic_pass]))
+    working.provenance.critic_pass = merged
+    return working

--- a/nl-poc/tests/nql/fixtures/like_passthrough.json
+++ b/nl-poc/tests/nql/fixtures/like_passthrough.json
@@ -1,0 +1,22 @@
+{
+  "nql_version": "0.1",
+  "intent": "detail",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "filters": [
+    {"field": "weapon", "op": "like", "value": "%firearm%", "type": "text_raw"}
+  ],
+  "time": {
+    "grain": "month",
+    "window": {
+      "type": "relative_months",
+      "n": 6,
+      "end": "2024-09-01"
+    }
+  },
+  "group_by": [],
+  "sort": [],
+  "limit": 100
+}

--- a/nl-poc/tests/nql/fixtures/limit_clamp.json
+++ b/nl-poc/tests/nql/fixtures/limit_clamp.json
@@ -1,0 +1,23 @@
+{
+  "nql_version": "0.1",
+  "intent": "detail",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "time": {
+    "grain": "month",
+    "window": {
+      "type": "relative_months",
+      "n": 24,
+      "end": "2024-09-01"
+    }
+  },
+  "filters": [],
+  "group_by": [],
+  "sort": [],
+  "limit": 50000,
+  "flags": {
+    "rowcap_hint": 5000
+  }
+}

--- a/nl-poc/tests/nql/fixtures/mom_single_month.json
+++ b/nl-poc/tests/nql/fixtures/mom_single_month.json
@@ -1,0 +1,25 @@
+{
+  "nql_version": "0.1",
+  "intent": "compare",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "filters": [
+    {"field": "month", "op": "=", "value": "2024-08-01", "type": "date"}
+  ],
+  "time": {
+    "grain": "month",
+    "window": {
+      "type": "single_month",
+      "start": "2024-08-01"
+    }
+  },
+  "compare": {
+    "type": "mom",
+    "baseline": "previous_period"
+  },
+  "group_by": [],
+  "sort": [],
+  "limit": 100
+}

--- a/nl-poc/tests/nql/fixtures/quarter.json
+++ b/nl-poc/tests/nql/fixtures/quarter.json
@@ -1,0 +1,28 @@
+{
+  "nql_version": "0.1",
+  "intent": "aggregate",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "filters": [
+    {
+      "field": "month",
+      "op": "between",
+      "value": ["2024-01-01", "2024-04-01"],
+      "type": "date"
+    }
+  ],
+  "time": {
+    "grain": "month",
+    "window": {
+      "type": "quarter",
+      "start": "2024-01-01",
+      "end": "2024-04-01",
+      "exclusive_end": true
+    }
+  },
+  "group_by": [],
+  "sort": [],
+  "limit": 100
+}

--- a/nl-poc/tests/nql/fixtures/relative_months.json
+++ b/nl-poc/tests/nql/fixtures/relative_months.json
@@ -1,0 +1,20 @@
+{
+  "nql_version": "0.1",
+  "intent": "aggregate",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "time": {
+    "grain": "month",
+    "window": {
+      "type": "relative_months",
+      "n": 12,
+      "end": "2024-09-01"
+    }
+  },
+  "filters": [],
+  "group_by": [],
+  "sort": [],
+  "limit": 100
+}

--- a/nl-poc/tests/nql/fixtures/single_month.json
+++ b/nl-poc/tests/nql/fixtures/single_month.json
@@ -1,0 +1,19 @@
+{
+  "nql_version": "0.1",
+  "intent": "aggregate",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "dimensions": [],
+  "filters": [
+    {"field": "month", "op": "=", "value": "2023-06-01", "type": "date"}
+  ],
+  "time": {
+    "grain": "month",
+    "window": {"type": "single_month", "start": "2023-06-01"}
+  },
+  "group_by": [],
+  "sort": [],
+  "limit": 100
+}

--- a/nl-poc/tests/nql/fixtures/sort_invalid.json
+++ b/nl-poc/tests/nql/fixtures/sort_invalid.json
@@ -1,0 +1,22 @@
+{
+  "nql_version": "0.1",
+  "intent": "aggregate",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "time": {
+    "grain": "month",
+    "window": {
+      "type": "relative_months",
+      "n": 3,
+      "end": "2024-09-01"
+    }
+  },
+  "filters": [],
+  "group_by": [],
+  "sort": [
+    {"by": "unknown_metric", "dir": "desc"}
+  ],
+  "limit": 100
+}

--- a/nl-poc/tests/nql/fixtures/strict_json_invalid_field.json
+++ b/nl-poc/tests/nql/fixtures/strict_json_invalid_field.json
@@ -1,0 +1,22 @@
+{
+  "nql_version": "0.1",
+  "intent": "aggregate",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "time": {
+    "grain": "month",
+    "window": {
+      "type": "single_month",
+      "start": "2024-01-01"
+    }
+  },
+  "filters": [
+    {"field": "month", "op": "=", "value": "2024-01-01", "type": "date"}
+  ],
+  "group_by": [],
+  "sort": [],
+  "limit": 100,
+  "unknown": "should_fail"
+}

--- a/nl-poc/tests/nql/fixtures/trend_default.json
+++ b/nl-poc/tests/nql/fixtures/trend_default.json
@@ -1,0 +1,19 @@
+{
+  "nql_version": "0.1",
+  "intent": "trend",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "time": {
+    "grain": "month",
+    "window": {
+      "type": "relative_months",
+      "end": "2024-09-01"
+    }
+  },
+  "filters": [],
+  "group_by": [],
+  "sort": [],
+  "limit": 100
+}

--- a/nl-poc/tests/nql/fixtures/ytd.json
+++ b/nl-poc/tests/nql/fixtures/ytd.json
@@ -1,0 +1,20 @@
+{
+  "nql_version": "0.1",
+  "intent": "aggregate",
+  "dataset": "la_crime",
+  "metrics": [
+    {"name": "incidents", "agg": "count", "alias": "incidents"}
+  ],
+  "time": {
+    "grain": "month",
+    "window": {
+      "type": "ytd",
+      "start": "2024-01-01",
+      "end": "2024-09-01"
+    }
+  },
+  "filters": [],
+  "group_by": [],
+  "sort": [],
+  "limit": 100
+}

--- a/nl-poc/tests/nql/test_nql_compiler.py
+++ b/nl-poc/tests/nql/test_nql_compiler.py
@@ -1,0 +1,159 @@
+"""Golden tests for the NQL validator and compiler."""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+if "yaml" not in sys.modules:
+    yaml_stub = ModuleType("yaml")
+    yaml_stub.safe_load = lambda stream: {}
+    sys.modules["yaml"] = yaml_stub
+
+if "duckdb" not in sys.modules:
+    duckdb_stub = ModuleType("duckdb")
+    duckdb_stub.connect = lambda path: None
+    duckdb_stub.DuckDBPyConnection = object
+    duckdb_stub.Error = Exception
+    sys.modules["duckdb"] = duckdb_stub
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from app.nql import NQLValidationError, compile_payload
+from app.resolver import PlanResolver, SemanticDimension, SemanticMetric, SemanticModel
+
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+class _ExecutorStub:
+    def find_closest_value(self, dimension, value):
+        return value
+
+    def closest_matches(self, dimension, value, limit: int = 5):  # pragma: no cover - defensive
+        return []
+
+    def parse_date(self, value: str) -> date:
+        return date.fromisoformat(value)
+
+
+def _semantic_model() -> SemanticModel:
+    return SemanticModel(
+        table="la_crime_raw",
+        date_grain="month",
+        dimensions={
+            "month": SemanticDimension(name="month", column="DATE OCC"),
+            "weapon": SemanticDimension(name="weapon", column="Weapon Desc"),
+        },
+        metrics={
+            "incidents": SemanticMetric(name="incidents", agg="count", grain=["month"]),
+        },
+    )
+
+
+def _load_fixture(name: str) -> dict:
+    path = _FIXTURE_DIR / name
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_single_month_equality_filter():
+    payload = _load_fixture("single_month.json")
+    compiled = compile_payload(payload)
+    plan = compiled.plan
+    assert plan["filters"] == [
+        {"field": "month", "op": "=", "value": "2023-06-01"}
+    ]
+    assert plan["limit"] == 100
+    assert plan["extras"]["rowcap_hint"] == 2000
+    assert "single_month_equality" in plan["_critic_pass"]
+
+
+def test_quarter_window_enforces_exclusive_end():
+    payload = _load_fixture("quarter.json")
+    compiled = compile_payload(payload)
+    plan = compiled.plan
+    assert plan["filters"] == [
+        {"field": "month", "op": "between", "value": ["2024-01-01", "2024-04-01"]}
+    ]
+    assert "quarter_exclusive_end" in plan["_critic_pass"]
+
+
+def test_relative_months_window_bounds():
+    payload = _load_fixture("relative_months.json")
+    compiled = compile_payload(payload)
+    plan = compiled.plan
+    assert plan["filters"] == [
+        {"field": "month", "op": "between", "value": ["2023-09-01", "2024-09-01"]}
+    ]
+
+
+def test_ytd_window_bounds():
+    payload = _load_fixture("ytd.json")
+    compiled = compile_payload(payload)
+    plan = compiled.plan
+    assert plan["filters"] == [
+        {"field": "month", "op": "between", "value": ["2024-01-01", "2024-09-01"]}
+    ]
+
+
+def test_like_passthrough_preserves_pattern():
+    payload = _load_fixture("like_passthrough.json")
+    compiled = compile_payload(payload)
+    plan = compiled.plan
+    assert plan["filters"][0] == {
+        "field": "weapon",
+        "op": "like",
+        "value": "%firearm%",
+    }
+    assert "like_passthrough" in plan["_critic_pass"]
+
+
+def test_mom_single_month_expands_internal_window():
+    payload = _load_fixture("mom_single_month.json")
+    compiled = compile_payload(payload)
+    resolver = PlanResolver(_semantic_model(), _ExecutorStub())
+    resolved = resolver.resolve(compiled.plan)
+    assert resolved["internal_window"] == {
+        "field": "month",
+        "op": "between",
+        "value": ["2024-07-01", "2024-09-01"],
+    }
+
+
+def test_trend_defaults_group_by_and_sort():
+    payload = _load_fixture("trend_default.json")
+    compiled = compile_payload(payload)
+    plan = compiled.plan
+    assert plan["group_by"] == ["month"]
+    assert plan["order_by"] == [{"field": "month", "dir": "asc"}]
+    assert plan["filters"] == [
+        {"field": "month", "op": "between", "value": ["2023-09-01", "2024-09-01"]}
+    ]
+    # validator should backfill the window span when omitted
+    assert compiled.nql.time.window.n == 12
+
+
+def test_invalid_sort_rejected():
+    payload = _load_fixture("sort_invalid.json")
+    with pytest.raises(NQLValidationError):
+        compile_payload(payload)
+
+
+def test_limit_clamp_enforced():
+    payload = _load_fixture("limit_clamp.json")
+    compiled = compile_payload(payload)
+    plan = compiled.plan
+    assert plan["limit"] == 2000
+    assert plan["extras"]["rowcap_hint"] == 2000
+    assert "limit_clamp" in plan["_critic_pass"]
+
+
+def test_strict_json_rejects_unknown_fields():
+    payload = _load_fixture("strict_json_invalid_field.json")
+    with pytest.raises(NQLValidationError):
+        compile_payload(payload)


### PR DESCRIPTION
## Summary
- add a schema-driven NQL package with typed models, validator rules, and compiler to existing plan format
- integrate the NQL path into the LLM planner, add telemetry logging, and expose an env flag toggle
- add fixture-based golden NQL tests that assert emitted plans and guard edge cases like limit clamp and sort safety

## Testing
- pytest tests/nql -q
- pytest tests/test_mom_single_month.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd62645ec0832ebfe2bb4eeb0e9211