### PR TITLE
Surface NQL engine status and fallback reasons

### DIFF
--- a/nl-poc/app/conversation.py
+++ b/nl-poc/app/conversation.py
@@ -1,0 +1,411 @@
+"""Conversation state management, rewriter, and clarifier utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Dict, List, Optional, Tuple
+
+import re
+from copy import deepcopy
+
+from .nql.model import CompareInternalWindow, CompareSpec, Filter, NQLQuery
+
+
+# Dimension canonical names that map to the semantic model.
+_DIMENSION_ALIASES = {
+    "area": {
+        "area",
+        "areas",
+        "area name",
+        "neighborhood",
+        "neighborhoods",
+    },
+    "weapon": {"weapon", "weapons", "weapon type", "weapon types", "weapon category"},
+    "crime_type": {
+        "crime",
+        "crimes",
+        "crime type",
+        "crime types",
+        "offense",
+        "offenses",
+    },
+    "premise": {"premise", "premises", "location type", "location"},
+    "vict_age": {"age", "ages", "victim age", "victim ages"},
+}
+
+_DIMENSION_TYPES = {
+    "area": "category",
+    "weapon": "category",
+    "crime_type": "category",
+    "premise": "category",
+    "vict_age": "number",
+}
+
+
+def _normalise_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _resolve_dimension(candidate: str) -> Optional[str]:
+    candidate_norm = _normalise_text(candidate)
+    candidate_norm = re.sub(r"[^a-z\s]", "", candidate_norm).strip()
+    if not candidate_norm:
+        return None
+    for canonical, synonyms in _DIMENSION_ALIASES.items():
+        if candidate_norm in synonyms or candidate_norm == canonical:
+            return canonical
+    return None
+
+
+def _extract_dimension_candidate(utterance: str) -> Optional[str]:
+    """Pull a possible dimension target from the utterance."""
+
+    lowered = utterance.lower()
+    patterns = [
+        r"same(?:\s+view)?\s+but\s+by\s+([a-z\s]+)",
+        r"by\s+([a-z\s]+)",
+        r"break(?:ing|)\s+down\s+by\s+([a-z\s]+)",
+        r"group\s+by\s+([a-z\s]+)",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, lowered)
+        if match:
+            candidate = match.group(1).strip()
+            candidate = re.sub(r"\bfor\b", "", candidate).strip()
+            return candidate
+    return None
+
+
+def _first_day_of_month(anchor: date) -> date:
+    return date(anchor.year, anchor.month, 1)
+
+
+def _shift_month(anchor: date, delta: int) -> date:
+    year = anchor.year + ((anchor.month - 1 + delta) // 12)
+    month = (anchor.month - 1 + delta) % 12 + 1
+    return date(year, month, 1)
+
+
+def _previous_month(anchor: date) -> date:
+    return _shift_month(anchor, -1)
+
+
+def _previous_quarter(anchor: date) -> Tuple[date, date]:
+    quarter_index = (anchor.month - 1) // 3
+    year = anchor.year
+    if quarter_index == 0:
+        year -= 1
+        quarter_index = 3
+    else:
+        quarter_index -= 1
+    start_month = quarter_index * 3 + 1
+    start = date(year, start_month, 1)
+    end_exclusive = _shift_month(start, 3)
+    return start, end_exclusive
+
+
+def _replace_month_filter(nql: NQLQuery, op: str, value: Any) -> None:
+    for filt in nql.filters:
+        if filt.field == "month":
+            filt.op = op
+            filt.value = value
+            filt.type = "date"
+            return
+    nql.filters.insert(0, Filter(field="month", op=op, value=value, type="date"))
+
+
+def _ensure_trend_group_by(nql: NQLQuery) -> None:
+    seen = set(nql.group_by)
+    if "month" not in seen:
+        nql.group_by.insert(0, "month")
+
+
+def _set_relative_months_window(
+    nql: NQLQuery, n: int, anchor_end: Optional[str]
+) -> None:
+    window = nql.time.window
+    window.type = "relative_months"
+    window.n = n
+    window.start = None
+    window.end = anchor_end
+    window.exclusive_end = False
+    end_str = anchor_end
+    if not end_str:
+        # fall back to existing month filter upper bound if present
+        for filt in nql.filters:
+            if filt.field == "month" and isinstance(filt.value, list) and len(filt.value) == 2:
+                end_str = filt.value[1]
+                break
+    if end_str:
+        end_date = date.fromisoformat(end_str)
+    else:
+        end_date = date.today()
+    start_date = _shift_month(end_date, -n)
+    _replace_month_filter(nql, "between", [start_date.isoformat(), end_date.isoformat()])
+
+
+def _set_single_month_window(nql: NQLQuery, start: date) -> None:
+    window = nql.time.window
+    window.type = "single_month"
+    window.start = start.isoformat()
+    window.end = None
+    window.exclusive_end = False
+    window.n = None
+    _replace_month_filter(nql, "=", start.isoformat())
+
+
+def _set_quarter_window(nql: NQLQuery, start: date, end_exclusive: date) -> None:
+    window = nql.time.window
+    window.type = "quarter"
+    window.start = start.isoformat()
+    window.end = end_exclusive.isoformat()
+    window.exclusive_end = True
+    window.n = None
+    _replace_month_filter(
+        nql,
+        "between",
+        [start.isoformat(), end_exclusive.isoformat()],
+    )
+
+
+def _toggle_mom_compare(nql: NQLQuery, enabled: bool) -> None:
+    if enabled:
+        if nql.compare and nql.compare.type == "mom":
+            return
+        nql.compare = CompareSpec(type="mom", internal_window=CompareInternalWindow())
+    else:
+        nql.compare = None
+
+
+def rewrite_followup(
+    conversation_state: Dict[str, Any], utterance: str, *, today: Optional[date] = None
+) -> Dict[str, Any]:
+    """Merge a follow-up utterance into the prior NQL conversation state."""
+
+    if not conversation_state:
+        raise ValueError("conversation_state cannot be empty for follow-up rewrites")
+
+    today = today or date.today()
+    working = NQLQuery.parse_obj(deepcopy(conversation_state))
+    working.provenance.utterance = utterance
+
+    lowered = utterance.lower()
+
+    candidate_dimension = _extract_dimension_candidate(utterance)
+    if candidate_dimension:
+        resolved = _resolve_dimension(candidate_dimension)
+        if resolved:
+            working.dimensions = [resolved]
+            # Remove duplicate entry if already present in group_by
+            working.group_by = [dim for dim in working.group_by if dim != resolved]
+
+    # Detect filter removals like "filter out Central"
+    remove_match = re.search(
+        r"(?:filter out|exclude|remove)\s+([\w\s'&/-]+)", lowered
+    )
+    if remove_match:
+        value = remove_match.group(1).strip().strip(". ")
+        value_norm = _normalise_text(value)
+        for filt in working.filters:
+            if isinstance(filt.value, str) and _normalise_text(str(filt.value)) == value_norm:
+                if filt.op == "=":
+                    filt.op = "!="
+                else:
+                    working.filters = [f for f in working.filters if f is not filt]
+                break
+
+    # Detect filter additions like "only Central" or "just show Hollywood"
+    add_match = re.search(r"(?:only|just)\s+([\w\s'&/-]+)", lowered)
+    if add_match:
+        value = add_match.group(1).strip().strip(". ")
+        field = None
+        if working.dimensions:
+            field = working.dimensions[0]
+        if not field:
+            # fall back to area if unsure
+            field = "area"
+        filt_type = _DIMENSION_TYPES.get(field, "category")
+        working.filters = [
+            f for f in working.filters if f.field != field or f.field == "month"
+        ]
+        working.filters.append(
+            Filter(field=field, op="=", value=value.title(), type=filt_type)
+        )
+
+    # Time adjustments
+    if "last quarter" in lowered:
+        start, end_exclusive = _previous_quarter(today)
+        _set_quarter_window(working, start, end_exclusive)
+    else:
+        match_relative = re.search(r"last\s+(\d{1,2})\s+months", lowered)
+        if match_relative:
+            n = int(match_relative.group(1))
+            anchor_end = working.time.window.end
+            _set_relative_months_window(working, n, anchor_end)
+        elif "last 6 months" in lowered:
+            anchor_end = working.time.window.end
+            _set_relative_months_window(working, 6, anchor_end)
+        elif "last 12 months" in lowered or "last year" in lowered:
+            anchor_end = working.time.window.end
+            _set_relative_months_window(working, 12, anchor_end)
+        elif "past 6 months" in lowered or "past six months" in lowered:
+            anchor_end = working.time.window.end
+            _set_relative_months_window(working, 6, anchor_end)
+        elif "last month" in lowered:
+            anchor_end = working.time.window.end
+            if anchor_end:
+                end_date = date.fromisoformat(anchor_end)
+            else:
+                end_date = today
+            start = _previous_month(end_date)
+            _set_single_month_window(working, start)
+
+    if "trend" in lowered:
+        working.intent = "trend"
+        _ensure_trend_group_by(working)
+
+    # MoM toggles
+    if re.search(r"(turn on|add|include).*(mom|month over month)", lowered):
+        _toggle_mom_compare(working, True)
+    elif re.search(r"(turn off|remove|drop).*(mom|month over month)", lowered):
+        _toggle_mom_compare(working, False)
+    elif re.search(r"\bmom\b", lowered) and "turn off" not in lowered:
+        _toggle_mom_compare(working, True)
+
+    return working.dict()
+
+
+@dataclass
+class ClarifierResult:
+    needs_clarification: bool
+    question: Optional[str] = None
+    missing_slots: List[str] = field(default_factory=list)
+    suggested_answers: List[str] = field(default_factory=list)
+    context: Dict[str, Any] = field(default_factory=dict)
+
+
+def assess_ambiguity(
+    conversation_state: Optional[Dict[str, Any]], utterance: str
+) -> ClarifierResult:
+    """Check whether a follow-up utterance is runnable without clarification."""
+
+    if not conversation_state:
+        return ClarifierResult(needs_clarification=False)
+
+    candidate_dimension = _extract_dimension_candidate(utterance)
+    if candidate_dimension and not _resolve_dimension(candidate_dimension):
+        suggestions = sorted(_DIMENSION_ALIASES.keys())[:4]
+        question = "Which dimension should I break that out by?"
+        return ClarifierResult(
+            needs_clarification=True,
+            question=question,
+            missing_slots=["dimension"],
+            suggested_answers=suggestions,
+            context={"dimension_candidate": candidate_dimension},
+        )
+
+    return ClarifierResult(needs_clarification=False)
+
+
+@dataclass
+class PendingClarification:
+    utterance: str
+    question: str
+    missing_slots: List[str]
+    suggested_answers: List[str]
+    context: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ConversationState:
+    session_id: str
+    last_nql: Optional[Dict[str, Any]] = None
+    last_plan: Optional[Dict[str, Any]] = None
+    pending: Optional[PendingClarification] = None
+
+
+class ConversationStore:
+    """In-memory registry of conversation state per session."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, ConversationState] = {}
+
+    def get(self, session_id: str) -> ConversationState:
+        if session_id not in self._sessions:
+            self._sessions[session_id] = ConversationState(session_id=session_id)
+        return self._sessions[session_id]
+
+    def peek(self, session_id: str) -> Optional[ConversationState]:
+        return self._sessions.get(session_id)
+
+    def update_last(self, session_id: str, nql: Dict[str, Any], plan: Dict[str, Any]) -> None:
+        state = self.get(session_id)
+        state.last_nql = deepcopy(nql)
+        state.last_plan = deepcopy(plan)
+        state.pending = None
+
+    def set_pending(
+        self,
+        session_id: str,
+        utterance: str,
+        question: str,
+        missing_slots: List[str],
+        suggested_answers: List[str],
+        *,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> PendingClarification:
+        state = self.get(session_id)
+        pending = PendingClarification(
+            utterance=utterance,
+            question=question,
+            missing_slots=missing_slots,
+            suggested_answers=suggested_answers,
+            context=context or {},
+        )
+        state.pending = pending
+        return pending
+
+    def clear_pending(self, session_id: str) -> None:
+        state = self.get(session_id)
+        state.pending = None
+
+
+def apply_clarification_answer(
+    conversation_state: Dict[str, Any],
+    pending: PendingClarification,
+    answer: str,
+    *,
+    today: Optional[date] = None,
+) -> Dict[str, Any]:
+    """Resolve a clarification answer and produce a runnable NQL payload."""
+
+    if not pending.missing_slots:
+        raise ValueError("Pending clarification has no missing slots")
+
+    if "dimension" in pending.missing_slots:
+        canonical = _resolve_dimension(answer)
+        if not canonical:
+            candidate = pending.context.get("dimension_candidate")
+            canonical = _resolve_dimension(candidate or "") or "area"
+        candidate = pending.context.get("dimension_candidate")
+        merged = pending.utterance
+        if candidate:
+            pattern = re.compile(re.escape(candidate), re.IGNORECASE)
+            merged = pattern.sub(canonical, merged, count=1)
+        else:
+            merged = f"{merged} by {canonical}"
+        return rewrite_followup(conversation_state, merged, today=today)
+
+    raise ValueError(f"Unsupported clarification slot(s): {pending.missing_slots}")
+
+
+__all__ = [
+    "ConversationState",
+    "ConversationStore",
+    "PendingClarification",
+    "ClarifierResult",
+    "assess_ambiguity",
+    "apply_clarification_answer",
+    "rewrite_followup",
+]
+

--- a/nl-poc/app/nql/__init__.py
+++ b/nl-poc/app/nql/__init__.py
@@ -19,10 +19,13 @@ class CompiledNQL:
     nql: NQLQuery
 
 
+_USE_NQL_FLAG = os.getenv("USE_NQL", "true").lower() in {"1", "true", "yes", "on"}
+
+
 def is_enabled() -> bool:
     """Return True if the NQL pipeline is enabled via environment flag."""
 
-    return os.getenv("USE_NQL", "true").lower() in {"1", "true", "yes", "on"}
+    return _USE_NQL_FLAG
 
 
 def compile_payload(payload: Dict[str, Any], today: Optional[date] = None) -> CompiledNQL:

--- a/nl-poc/frontend/index.html
+++ b/nl-poc/frontend/index.html
@@ -94,6 +94,17 @@
         background: #fef3c7;
         color: #78350f;
       }
+      .nql-status-banner {
+        display: none;
+        margin: 1rem 0;
+        padding: 0.75rem 1rem;
+        border-radius: 6px;
+        border: 1px solid #38bdf8;
+        background: #e0f2fe;
+        color: #0c4a6e;
+        font-size: 0.9rem;
+        font-weight: 500;
+      }
       .warning-panel h3 {
         margin: 0 0 0.5rem;
         font-size: 1rem;
@@ -171,7 +182,6 @@
       .filter-chip {
         display: inline-flex;
         align-items: center;
-        gap: 0.5rem;
         background: #dbeafe;
         color: #1e40af;
         border: 1px solid #93c5fd;
@@ -179,20 +189,6 @@
         padding: 0.35rem 0.75rem;
         font-size: 0.9rem;
         font-weight: 500;
-      }
-      .filter-chip .remove-btn {
-        background: transparent;
-        border: none;
-        color: #1e40af;
-        cursor: pointer;
-        padding: 0;
-        margin: 0;
-        font-size: 1.2rem;
-        line-height: 1;
-        font-weight: bold;
-      }
-      .filter-chip .remove-btn:hover {
-        color: #1e3a8a;
       }
 
       /* Action buttons */
@@ -209,6 +205,40 @@
       }
       .action-buttons button:hover {
         background: #059669;
+      }
+
+      .clarification-panel {
+        display: none;
+        background: #eef2ff;
+        border: 1px solid #c7d2fe;
+        border-radius: 6px;
+        padding: 1rem;
+        margin-top: 1rem;
+      }
+
+      .clarification-panel p {
+        margin: 0 0 0.75rem;
+        font-weight: 600;
+      }
+
+      .clarification-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      .clarification-options button {
+        background: #4f46e5;
+        border: none;
+        color: #fff;
+        padding: 0.4rem 0.8rem;
+        border-radius: 999px;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+
+      .clarification-options button:hover {
+        background: #4338ca;
       }
 
       /* History sidebar */
@@ -281,12 +311,18 @@
           <p id="error-message" class="error-message"></p>
           <div id="suggestions" class="suggestions"></div>
         </div>
+        <div id="clarification-panel" class="clarification-panel" aria-live="polite">
+          <p id="clarification-question"></p>
+          <div id="clarification-options" class="clarification-options"></div>
+        </div>
       </div>
       <div class="card" id="result-card" style="display: none;">
         <div class="result-header">
           <h2 id="answer"></h2>
           <div class="result-meta" id="result-meta" aria-live="polite"></div>
         </div>
+
+        <div id="nql-status" class="nql-status-banner" role="status" aria-live="polite"></div>
 
         <!-- Filter chips -->
         <div id="filter-chips" class="filter-chips"></div>
@@ -341,6 +377,7 @@
       const chartCanvas = document.getElementById('chart');
       const warningPanel = document.getElementById('warning-panel');
       const warningList = document.getElementById('warning-list');
+      const nqlStatusBanner = document.getElementById('nql-status');
 
       const resultMeta = document.getElementById('result-meta');
       const filterChipsContainer = document.getElementById('filter-chips');
@@ -349,10 +386,43 @@
       const copySqlBtn = document.getElementById('copy-sql-btn');
       const copyJsonBtn = document.getElementById('copy-json-btn');
       const downloadCsvBtn = document.getElementById('download-csv-btn');
+      const clarificationPanel = document.getElementById('clarification-panel');
+      const clarificationQuestionEl = document.getElementById('clarification-question');
+      const clarificationOptions = document.getElementById('clarification-options');
+
+      const SESSION_STORAGE_KEY = 'scout-session-id';
+
+      function generateSessionId() {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+          return crypto.randomUUID();
+        }
+        const random = Math.random().toString(16).slice(2);
+        return `session-${Date.now()}-${random}`;
+      }
+
+      function getSessionId() {
+        try {
+          const stored = window.localStorage?.getItem(SESSION_STORAGE_KEY);
+          if (stored) {
+            return stored;
+          }
+        } catch (err) {
+          // Ignore storage access issues and fall back to a fresh id
+        }
+        const fresh = generateSessionId();
+        try {
+          window.localStorage?.setItem(SESSION_STORAGE_KEY, fresh);
+        } catch (err) {
+          // Ignore storage write issues
+        }
+        return fresh;
+      }
 
       let chartInstance;
       let lastFailedQuery = '';
       let currentData = null;  // Store current result data
+      const sessionId = getSessionId();
+      let pendingClarification = null;
 
       const apiBase = window.location.port === '3000' ? 'http://127.0.0.1:8000' : window.location.origin;
 
@@ -371,41 +441,113 @@
         }
 
         hideErrorPanel();
+        renderNqlStatus(null);
         const originalButtonText = askBtn.textContent;
         askBtn.disabled = true;
-        askBtn.textContent = 'Thinking...';
+        askBtn.textContent = pendingClarification ? 'Clarifying...' : 'Thinking...';
 
         try {
-          const response = await fetch(`${apiBase}/ask`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ question })
-          });
-          if (!response.ok) {
-            let errorDetail = {};
-            try {
-              errorDetail = await response.json();
-            } catch (parseErr) {
-              // ignore JSON parse errors and fallback to generic message
-            }
-            const detail = errorDetail?.detail ?? errorDetail;
-            const message = typeof detail === 'string' ? detail : detail?.message || 'Request failed';
-            const suggestions = Array.isArray(detail?.suggestions) ? detail.suggestions : [];
-            const err = new Error(message);
-            err.suggestions = suggestions;
-            throw err;
+          if (pendingClarification) {
+            await sendClarificationAnswer(question);
+          } else {
+            await sendCompleteRequest(question);
           }
-          const data = await response.json();
-          renderResult(data);
         } catch (err) {
           const message = err?.message || 'Something went wrong';
           const suggestions = Array.isArray(err?.suggestions) ? err.suggestions : [];
-          lastFailedQuery = question;  // Save the query that failed
+          if (!pendingClarification) {
+            lastFailedQuery = question;
+          }
           showErrorPanel(message, suggestions);
         } finally {
           askBtn.disabled = false;
           askBtn.textContent = originalButtonText;
         }
+      }
+
+      async function sendCompleteRequest(utterance) {
+        const response = await fetch(`${apiBase}/chat/complete`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Session-Id': sessionId
+          },
+          body: JSON.stringify({ session_id: sessionId, utterance })
+        });
+        if (!response.ok) {
+          throw await buildError(response);
+        }
+        const data = await response.json();
+        if (data.status === 'clarification_needed') {
+          pendingClarification = {
+            question: data.question,
+            missing: data.missing_slots || [],
+            suggested: data.suggested_answers || [],
+            originalUtterance: utterance,
+          };
+          showClarificationPrompt(data);
+          return;
+        }
+        pendingClarification = null;
+        renderResult(data, utterance);
+      }
+
+      async function sendClarificationAnswer(answer) {
+        if (!pendingClarification) return;
+        const response = await fetch(`${apiBase}/chat/clarify`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Session-Id': sessionId
+          },
+          body: JSON.stringify({ session_id: sessionId, answer })
+        });
+        if (!response.ok) {
+          throw await buildError(response);
+        }
+        const data = await response.json();
+        const original = pendingClarification?.originalUtterance;
+        pendingClarification = null;
+        const combined = original ? `${original} (${answer})` : answer;
+        renderResult(data, combined);
+      }
+
+      async function buildError(response) {
+        let errorDetail = {};
+        try {
+          errorDetail = await response.json();
+        } catch (parseErr) {
+          // ignore JSON parse errors and fallback to generic message
+        }
+        const detail = errorDetail?.detail ?? errorDetail;
+        const message = typeof detail === 'string' ? detail : detail?.message || 'Request failed';
+        const suggestions = Array.isArray(detail?.suggestions) ? detail.suggestions : [];
+        const err = new Error(message);
+        err.suggestions = suggestions;
+        return err;
+      }
+
+      function showClarificationPrompt(data) {
+        renderNqlStatus(null);
+        clarificationQuestionEl.textContent = data.question || 'Can you clarify?';
+        clarificationOptions.innerHTML = '';
+        const answers = data.suggested_answers || [];
+        answers.slice(0, 4).forEach(answer => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.textContent = answer;
+          button.addEventListener('click', () => submitQuestion(answer));
+          clarificationOptions.appendChild(button);
+        });
+        clarificationPanel.style.display = 'block';
+        questionInput.value = '';
+        questionInput.focus();
+      }
+
+      function hideClarificationPrompt() {
+        clarificationPanel.style.display = 'none';
+        clarificationQuestionEl.textContent = '';
+        clarificationOptions.innerHTML = '';
       }
 
       function hideErrorPanel() {
@@ -453,24 +595,55 @@
         errorPanel.style.display = 'block';
       }
 
-      function renderResult(data) {
+      function renderResult(data, utterance) {
+        hideClarificationPrompt();
         currentData = data;  // Store current data
-        currentData.question = questionInput.value;  // Store the question too
+        currentData.question = utterance;
 
         resultCard.style.display = 'block';
         answerEl.textContent = data.answer;
         renderMetadata(data);
+        renderNqlStatus(data.nql_status || null);
         renderWarnings(data.warnings || []);
         sqlEl.textContent = data.sql;
         planEl.textContent = JSON.stringify(data.plan, null, 2);
         lineageEl.textContent = JSON.stringify(data.lineage, null, 2);
         renderTable(data.table);
         renderChart(data.chart);
-        renderFilterChips(data.plan);
+        renderPlanChips(data.chips);
         actionButtonsContainer.style.display = 'flex';
 
         // Add to history
-        addToHistory(questionInput.value);
+        addToHistory(utterance);
+        questionInput.value = '';
+      }
+
+      function renderNqlStatus(status) {
+        if (!status || status.valid) {
+          nqlStatusBanner.style.display = 'none';
+          nqlStatusBanner.textContent = '';
+          nqlStatusBanner.removeAttribute('title');
+          return;
+        }
+
+        let message;
+        if (status.attempted === false) {
+          const reason = status.reason || 'nql_not_attempted';
+          message = `NQL not used (${reason})`;
+        } else {
+          const stage = status.stage ? status.stage.toUpperCase() : 'UNKNOWN';
+          const reason = status.reason || 'error';
+          const fallback = status.fallback ? status.fallback.toUpperCase() : 'LEGACY';
+          message = `NQL fallback (${stage}): ${reason} → ${fallback}`;
+        }
+
+        nqlStatusBanner.textContent = message;
+        if (status.detail) {
+          nqlStatusBanner.title = status.detail;
+        } else {
+          nqlStatusBanner.removeAttribute('title');
+        }
+        nqlStatusBanner.style.display = 'block';
       }
 
       function renderWarnings(warnings) {
@@ -486,7 +659,9 @@
       function renderMetadata(data) {
         const badges = [];
         if (data.engine) {
-          badges.push(`<span><strong>Engine:</strong> ${data.engine}</span>`);
+          const engine = typeof data.engine === 'string' ? data.engine.toLowerCase() : '';
+          const engineLabel = engine === 'nql' ? 'NQL' : engine === 'legacy' ? 'Legacy' : data.engine;
+          badges.push(`<span><strong>Engine:</strong> ${engineLabel}</span>`);
         }
         const runtime = formatRuntime(data.runtime_ms);
         if (runtime) {
@@ -628,108 +803,48 @@
         }
       }
 
-      // ============ Filter Chips ============
-      function renderFilterChips(plan) {
-        if (!plan || !plan.filters || plan.filters.length === 0) {
+      // ============ Plan Chips ============
+      function renderPlanChips(chips) {
+        const groups = [
+          { label: 'Time', values: (chips && chips.time) || [] },
+          { label: 'Dimensions', values: (chips && chips.dimensions) || [] },
+          { label: 'Filters', values: (chips && chips.filters) || [] },
+        ];
+
+        const items = [];
+        groups.forEach(group => {
+          group.values.forEach(value => {
+            items.push({ label: group.label, value });
+          });
+        });
+
+        if (!items.length) {
           filterChipsContainer.style.display = 'none';
+          filterChipsContainer.innerHTML = '';
           return;
         }
 
         filterChipsContainer.innerHTML = '';
         filterChipsContainer.style.display = 'flex';
 
-        plan.filters.forEach((filter, index) => {
+        items.forEach(item => {
           const chip = document.createElement('div');
           chip.className = 'filter-chip';
-
-          const label = formatFilterLabel(filter);
-          const labelSpan = document.createElement('span');
-          labelSpan.textContent = label;
-
-          const removeBtn = document.createElement('button');
-          removeBtn.className = 'remove-btn';
-          removeBtn.textContent = '×';
-          removeBtn.title = 'Remove filter';
-          removeBtn.addEventListener('click', () => removeFilterAndRerun(index));
-
-          chip.appendChild(labelSpan);
-          chip.appendChild(removeBtn);
+          chip.textContent = `${item.label}: ${item.value}`;
           filterChipsContainer.appendChild(chip);
         });
       }
 
-      function formatFilterLabel(filter) {
-        const field = filter.field;
-        const op = filter.op;
-        const value = filter.value;
-
-        if (op === 'between' && Array.isArray(value)) {
-          return `${field}: ${value[0]} to ${value[1]}`;
-        } else if (op === 'in' && Array.isArray(value)) {
-          return `${field}: ${value.join(', ')}`;
-        } else if (op === 'like_any' && Array.isArray(value)) {
-          return `${field}: contains pattern`;
-        } else {
-          return `${field}: ${value}`;
-        }
-      }
-
-      function removeFilterAndRerun(filterIndex) {
-        if (!currentData || !currentData.plan) return;
-
-        // Create a new question by reconstructing from the plan without this filter
-        // Since we don't have perfect query reconstruction, we'll use a modified plan approach
-        const newFilters = currentData.plan.filters.filter((_, idx) => idx !== filterIndex);
-
-        // For simplicity, we'll construct a basic query from remaining filters
-        // In a production system, you'd want to store the original query structure
-        const baseQuery = reconstructQueryFromPlan(currentData.plan, newFilters);
-
-        questionInput.value = baseQuery;
-        submitQuestion(baseQuery);
-      }
-
-      function reconstructQueryFromPlan(plan, filters) {
-        // Basic query reconstruction - this is simplified
-        // In production, you'd want more sophisticated query building
-        let parts = [];
-
-        // Add metric
-        parts.push('Show incidents');
-
-        // Add grouping
-        if (plan.group_by && plan.group_by.length > 0) {
-          parts.push(`by ${plan.group_by.join(', ')}`);
-        }
-
-        // Add filters
-        filters.forEach(filter => {
-          if (filter.field === 'month') {
-            if (filter.op === 'between' && Array.isArray(filter.value)) {
-              parts.push(`from ${filter.value[0]} to ${filter.value[1]}`);
-            } else {
-              parts.push(`in ${filter.value}`);
-            }
-          } else if (filter.op === 'in' && Array.isArray(filter.value)) {
-            parts.push(`in ${filter.value.join(' or ')}`);
-          } else if (filter.op !== 'like_any') {
-            parts.push(`in ${filter.value}`);
-          }
-        });
-
-        return parts.join(' ');
-      }
-
       // ============ Copy/Download Buttons ============
-      copySqlBtn.addEventListener('click', () => {
+      copySqlBtn.addEventListener('click', event => {
         if (!currentData || !currentData.sql) return;
-        copyToClipboard(currentData.sql, 'SQL copied to clipboard!');
+        copyToClipboard(currentData.sql, event.currentTarget);
       });
 
-      copyJsonBtn.addEventListener('click', () => {
+      copyJsonBtn.addEventListener('click', event => {
         if (!currentData || !currentData.plan) return;
         const jsonStr = JSON.stringify(currentData.plan, null, 2);
-        copyToClipboard(jsonStr, 'JSON plan copied to clipboard!');
+        copyToClipboard(jsonStr, event.currentTarget);
       });
 
       downloadCsvBtn.addEventListener('click', () => {
@@ -737,14 +852,15 @@
         downloadAsCSV(currentData.table, 'scout-results.csv');
       });
 
-      function copyToClipboard(text, successMessage) {
+      function copyToClipboard(text, button) {
         navigator.clipboard.writeText(text).then(() => {
-          // Show temporary success message
-          const originalText = event.target.textContent;
-          event.target.textContent = '✓ Copied!';
-          setTimeout(() => {
-            event.target.textContent = originalText;
-          }, 2000);
+          if (button) {
+            const originalText = button.textContent;
+            button.textContent = '✓ Copied!';
+            setTimeout(() => {
+              button.textContent = originalText;
+            }, 2000);
+          }
         }).catch(err => {
           console.error('Failed to copy:', err);
           alert('Failed to copy to clipboard');

--- a/nl-poc/tests/conversations/fixtures/clarifier_dimension.json
+++ b/nl-poc/tests/conversations/fixtures/clarifier_dimension.json
@@ -1,0 +1,142 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+    ],
+    "dimensions": [],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "same but by district",
+      "clarification": {
+        "question": "Which dimension should I break that out by?",
+        "answer": "area",
+        "missing_slots": ["dimension"],
+        "suggested_answers": ["area", "crime_type", "premise", "vict_age"]
+      },
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "same but by area",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "now show trend for last quarter",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "trend",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "quarter",
+            "start": "2024-04-01",
+            "end": "2024-07-01",
+            "exclusive_end": true,
+            "n": null
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2024-04-01", "2024-07-01"], "type": "date", "notes": null}
+        ],
+        "compare": null,
+        "group_by": ["month"],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now show trend for last quarter",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/clarifier_to_premise.json
+++ b/nl-poc/tests/conversations/fixtures/clarifier_to_premise.json
@@ -1,0 +1,143 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+    ],
+    "dimensions": [],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "same but by district",
+      "clarification": {
+        "question": "Which dimension should I break that out by?",
+        "answer": "premise",
+        "missing_slots": ["dimension"],
+        "suggested_answers": ["area", "crime_type", "premise", "vict_age"]
+      },
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["premise"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "same but by premise",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "now just bar",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["premise"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "premise", "op": "=", "value": "Bar", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now just bar",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/coreference_premise.json
+++ b/nl-poc/tests/conversations/fixtures/coreference_premise.json
@@ -1,0 +1,137 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+    ],
+    "dimensions": ["area"],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "same but by premise",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["premise"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "same but by premise",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "just bar",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["premise"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "premise", "op": "=", "value": "Bar", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "just bar",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/coreference_weapon.json
+++ b/nl-poc/tests/conversations/fixtures/coreference_weapon.json
@@ -1,0 +1,139 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+      {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+    ],
+    "dimensions": ["area"],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "same but by weapon",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["weapon"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "same but by weapon",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "now show trend for last 6 months",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "trend",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 6
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["weapon"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2024-01-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": ["month"],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now show trend for last 6 months",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/filter_case_insensitive.json
+++ b/nl-poc/tests/conversations/fixtures/filter_case_insensitive.json
@@ -1,0 +1,139 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+      {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+    ],
+    "dimensions": ["area"],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "filter out central",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "!=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "filter out central",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "now just hollywood",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "=", "value": "Hollywood", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now just hollywood",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/filters_add_remove.json
+++ b/nl-poc/tests/conversations/fixtures/filters_add_remove.json
@@ -1,0 +1,138 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+    ],
+    "dimensions": ["area"],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "only Central",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "only Central",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "filter out Central",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "!=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "filter out Central",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/filters_negation.json
+++ b/nl-poc/tests/conversations/fixtures/filters_negation.json
@@ -1,0 +1,139 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+      {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+    ],
+    "dimensions": ["area"],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "filter out Central",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "!=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "filter out Central",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "just Downtown",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "=", "value": "Downtown", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "just Downtown",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/mom_toggle.json
+++ b/nl-poc/tests/conversations/fixtures/mom_toggle.json
@@ -1,0 +1,143 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "single_month",
+        "start": "2024-06-01",
+        "end": null,
+        "exclusive_end": false,
+        "n": null
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "=", "value": "2024-06-01", "type": "date", "notes": null}
+    ],
+    "dimensions": [],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "compare": null,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "turn on MoM",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "single_month",
+            "start": "2024-06-01",
+            "end": null,
+            "exclusive_end": false,
+            "n": null
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": [],
+        "filters": [
+          {"field": "month", "op": "=", "value": "2024-06-01", "type": "date", "notes": null}
+        ],
+        "compare": {
+          "type": "mom",
+          "baseline": null,
+          "internal_window": {
+            "expand_prior": false
+          }
+        },
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "turn on MoM",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "turn off MoM",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "single_month",
+            "start": "2024-06-01",
+            "end": null,
+            "exclusive_end": false,
+            "n": null
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": [],
+        "filters": [
+          {"field": "month", "op": "=", "value": "2024-06-01", "type": "date", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "turn off MoM",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/multi_turn_combo.json
+++ b/nl-poc/tests/conversations/fixtures/multi_turn_combo.json
@@ -1,0 +1,185 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+      {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+    ],
+    "dimensions": ["area"],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "same but by weapon",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["weapon"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "same but by weapon",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "filter out Central",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "aggregate",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["weapon"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "!=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": [],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "filter out Central",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "now show trend for last quarter",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "trend",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "quarter",
+            "start": "2024-04-01",
+            "end": "2024-07-01",
+            "exclusive_end": true,
+            "n": null
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["weapon"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2024-04-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "!=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": ["month"],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now show trend for last quarter",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/time_quarter_and_month.json
+++ b/nl-poc/tests/conversations/fixtures/time_quarter_and_month.json
@@ -1,0 +1,139 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null},
+      {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+    ],
+    "dimensions": ["area"],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "now show trend for last quarter",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "trend",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "quarter",
+            "start": "2024-04-01",
+            "end": "2024-07-01",
+            "exclusive_end": true,
+            "n": null
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2024-04-01", "2024-07-01"], "type": "date", "notes": null},
+          {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": ["month"],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now show trend for last quarter",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "now last month",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "trend",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "single_month",
+            "start": "2024-06-01",
+            "end": null,
+            "exclusive_end": false,
+            "n": null
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["area"],
+        "filters": [
+          {"field": "month", "op": "=", "value": "2024-06-01", "type": "date", "notes": null},
+          {"field": "area", "op": "=", "value": "Central", "type": "category", "notes": null}
+        ],
+        "compare": null,
+        "group_by": ["month"],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now last month",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/time_relative_windows.json
+++ b/nl-poc/tests/conversations/fixtures/time_relative_windows.json
@@ -1,0 +1,136 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+    ],
+    "dimensions": [],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "now show trend for last 12 months",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "trend",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": [],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+        ],
+        "compare": null,
+        "group_by": ["month"],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now show trend for last 12 months",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "now past 6 months",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "trend",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 6
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": [],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2024-01-01", "2024-07-01"], "type": "date", "notes": null}
+        ],
+        "compare": null,
+        "group_by": ["month"],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now past 6 months",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/fixtures/trend_groupby_month.json
+++ b/nl-poc/tests/conversations/fixtures/trend_groupby_month.json
@@ -1,0 +1,136 @@
+{
+  "today": "2024-07-15",
+  "initial_nql": {
+    "nql_version": "0.1",
+    "intent": "aggregate",
+    "dataset": "la_crime",
+    "metrics": [
+      {"name": "incidents", "agg": "count", "alias": "incidents"}
+    ],
+    "time": {
+      "grain": "month",
+      "window": {
+        "type": "relative_months",
+        "start": null,
+        "end": "2024-07-01",
+        "exclusive_end": false,
+        "n": 12
+      },
+      "tz": "America/Chicago"
+    },
+    "filters": [
+      {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+    ],
+    "dimensions": ["weapon"],
+    "group_by": [],
+    "sort": [],
+    "limit": 100,
+    "flags": {
+      "trend": null,
+      "strict_json": true,
+      "require_grouping_for_trend": true,
+      "like_passthrough": true,
+      "single_month_equals": true,
+      "quarter_exclusive_end": true,
+      "rowcap_hint": 10000
+    },
+    "provenance": {
+      "utterance": null,
+      "retrieval_notes": [],
+      "confidence": null,
+      "critic_pass": []
+    }
+  },
+  "turns": [
+    {
+      "utterance": "now show trend",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "trend",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "relative_months",
+            "start": null,
+            "end": "2024-07-01",
+            "exclusive_end": false,
+            "n": 12
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["weapon"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2023-07-01", "2024-07-01"], "type": "date", "notes": null}
+        ],
+        "compare": null,
+        "group_by": ["month"],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now show trend",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    },
+    {
+      "utterance": "now show trend for last quarter",
+      "expected": {
+        "nql_version": "0.1",
+        "intent": "trend",
+        "dataset": "la_crime",
+        "metrics": [
+          {"name": "incidents", "agg": "count", "alias": "incidents"}
+        ],
+        "time": {
+          "grain": "month",
+          "window": {
+            "type": "quarter",
+            "start": "2024-04-01",
+            "end": "2024-07-01",
+            "exclusive_end": true,
+            "n": null
+          },
+          "tz": "America/Chicago"
+        },
+        "dimensions": ["weapon"],
+        "filters": [
+          {"field": "month", "op": "between", "value": ["2024-04-01", "2024-07-01"], "type": "date", "notes": null}
+        ],
+        "compare": null,
+        "group_by": ["month"],
+        "sort": [],
+        "limit": 100,
+        "flags": {
+          "trend": null,
+          "strict_json": true,
+          "require_grouping_for_trend": true,
+          "like_passthrough": true,
+          "single_month_equals": true,
+          "quarter_exclusive_end": true,
+          "rowcap_hint": 10000
+        },
+        "provenance": {
+          "utterance": "now show trend for last quarter",
+          "retrieval_notes": [],
+          "confidence": null,
+          "critic_pass": []
+        }
+      }
+    }
+  ]
+}

--- a/nl-poc/tests/conversations/test_conversations.py
+++ b/nl-poc/tests/conversations/test_conversations.py
@@ -1,0 +1,64 @@
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.conversation import (
+    PendingClarification,
+    apply_clarification_answer,
+    assess_ambiguity,
+    rewrite_followup,
+)
+from app.nql.model import NQLQuery
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _normalise(nql_payload):
+    return NQLQuery.parse_obj(nql_payload).dict()
+
+
+@pytest.mark.parametrize("fixture_path", sorted(FIXTURES_DIR.glob("*.json")))
+def test_conversation_fixture(fixture_path: Path):
+    payload = json.loads(fixture_path.read_text())
+    today_value = date.fromisoformat(payload["today"])
+    state = _normalise(payload["initial_nql"])
+
+    for turn in payload["turns"]:
+        utterance = turn["utterance"]
+        expected = _normalise(turn["expected"])
+        clarification = turn.get("clarification")
+
+        if clarification:
+            result = assess_ambiguity(state, utterance)
+            assert result.needs_clarification, f"Expected clarification for {fixture_path.name}"
+            assert result.question == clarification["question"]
+            assert result.missing_slots == clarification["missing_slots"]
+            assert result.suggested_answers == clarification["suggested_answers"]
+            pending = PendingClarification(
+                utterance=utterance,
+                question=result.question or "",
+                missing_slots=result.missing_slots,
+                suggested_answers=result.suggested_answers,
+                context=result.context,
+            )
+            actual = apply_clarification_answer(
+                state,
+                pending,
+                clarification["answer"],
+                today=today_value,
+            )
+        else:
+            result = assess_ambiguity(state, utterance)
+            assert not result.needs_clarification, f"Unexpected clarification for {fixture_path.name}"
+            actual = rewrite_followup(state, utterance, today=today_value)
+
+        normalised_actual = _normalise(actual)
+        assert normalised_actual == expected
+        state = normalised_actual


### PR DESCRIPTION
## Summary
- resolve chat sessions from the body or X-Session-Id header, track USE_NQL at startup, and return engine/nql_status metadata with a debug-state endpoint
- persist per-build planner NQL status so fallback reasons surface alongside the legacy engine
- persist session ids in the UI, send them with every chat request, and render engine badges plus inline banners for NQL fallbacks

## Testing
- pytest nl-poc/tests/conversations -q

------
https://chatgpt.com/codex/tasks/task_e_68dd6efff7e4832e959a24c9de1ce1c0