### PR TITLE
Improve NQL gating observability

### DIFF
--- a/nl-poc/app/nql/__init__.py
+++ b/nl-poc/app/nql/__init__.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any, Dict, Optional
 
+from ..llm_client import _load_env_once
 from .model import NQLQuery
 from .validator import NQLValidationError, validate_nql
 from .compiler import compile_nql_query
@@ -19,13 +20,35 @@ class CompiledNQL:
     nql: NQLQuery
 
 
-_USE_NQL_FLAG = os.getenv("USE_NQL", "true").lower() in {"1", "true", "yes", "on"}
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _coerce_env_flag(raw_value: Optional[str], *, default: bool = True) -> bool:
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in _TRUE_VALUES
+
+
+def use_nql_enabled() -> bool:
+    """Return True if the NQL pipeline is enabled via environment flag."""
+
+    _load_env_once()
+    raw = os.getenv("USE_NQL")
+    return _coerce_env_flag(raw)
 
 
 def is_enabled() -> bool:
-    """Return True if the NQL pipeline is enabled via environment flag."""
+    """Backwards-compatible wrapper for the legacy flag getter."""
 
-    return _USE_NQL_FLAG
+    return use_nql_enabled()
+
+
+def flag_state() -> Dict[str, Any]:
+    """Return a snapshot of the USE_NQL flag raw value and computed state."""
+
+    _load_env_once()
+    raw = os.getenv("USE_NQL")
+    return {"raw": raw, "enabled": _coerce_env_flag(raw)}
 
 
 def compile_payload(payload: Dict[str, Any], today: Optional[date] = None) -> CompiledNQL:
@@ -46,5 +69,7 @@ __all__ = [
     "NQLQuery",
     "NQLValidationError",
     "compile_payload",
+    "flag_state",
     "is_enabled",
+    "use_nql_enabled",
 ]

--- a/nl-poc/app/planner.py
+++ b/nl-poc/app/planner.py
@@ -19,7 +19,7 @@ from .synonyms import (
     load_synonyms,
     weapon_patterns_from_value,
 )
-from .nql import NQLValidationError, compile_payload, is_enabled as nql_is_enabled
+from .nql import NQLValidationError, compile_payload, use_nql_enabled
 from .time_utils import TimeRange, extract_time_range, trailing_year_range
 
 PROMPT_PATH = pathlib.Path(__file__).parent / "llm_prompt_intent.txt"
@@ -457,7 +457,7 @@ def build_plan_llm(question: str) -> Dict[str, object]:
         raise RuntimeError(f"LLM returned non-JSON payload: {raw[:200]}...") from exc
 
     bundle = load_synonyms()
-    if nql_is_enabled() and isinstance(payload, dict) and payload.get("nql_version"):
+    if use_nql_enabled() and isinstance(payload, dict) and payload.get("nql_version"):
         try:
             compiled = compile_payload(payload)
         except NQLValidationError as exc:

--- a/nl-poc/tests/test_nql_gate.py
+++ b/nl-poc/tests/test_nql_gate.py
@@ -1,0 +1,180 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+if "duckdb" not in sys.modules:
+    duckdb_stub = ModuleType("duckdb")
+    duckdb_stub.connect = lambda path: None
+    duckdb_stub.DuckDBPyConnection = object
+    duckdb_stub.Error = Exception
+    sys.modules["duckdb"] = duckdb_stub
+
+if "fastapi" not in sys.modules:
+    fastapi_stub = ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    def Header(default=None, **_kwargs):  # pragma: no cover - simple stub
+        return default
+
+    class FastAPI:  # pragma: no cover - minimal test stub
+        def __init__(self, *args, **kwargs):
+            self._middlewares = []
+
+        def add_middleware(self, *args, **kwargs):
+            self._middlewares.append((args, kwargs))
+
+        def on_event(self, _event: str):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def get(self, _path: str):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def post(self, _path: str):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    fastapi_stub.FastAPI = FastAPI
+    fastapi_stub.HTTPException = HTTPException
+    fastapi_stub.Header = Header
+
+    cors_module = ModuleType("fastapi.middleware.cors")
+
+    class CORSMiddleware:  # pragma: no cover - minimal test stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    cors_module.CORSMiddleware = CORSMiddleware
+    middleware_module = ModuleType("fastapi.middleware")
+    middleware_module.cors = cors_module
+
+    fastapi_stub.middleware = middleware_module
+
+    sys.modules["fastapi"] = fastapi_stub
+    sys.modules["fastapi.middleware"] = middleware_module
+    sys.modules["fastapi.middleware.cors"] = cors_module
+
+if "pydantic" not in sys.modules:
+    pydantic_stub = ModuleType("pydantic")
+
+    class BaseModel:  # pragma: no cover - lightweight stand-in
+        def __init__(self, **data):
+            annotations = getattr(self.__class__, "__annotations__", {})
+            for name, _ in annotations.items():
+                if name in data:
+                    setattr(self, name, data[name])
+                else:
+                    setattr(self, name, getattr(self.__class__, name, None))
+            for extra_key, extra_value in data.items():
+                if extra_key not in annotations:
+                    setattr(self, extra_key, extra_value)
+
+        def dict(self, *args, **kwargs):
+            annotations = getattr(self.__class__, "__annotations__", {})
+            return {name: getattr(self, name, None) for name in annotations}
+
+        @classmethod
+        def parse_obj(cls, data):
+            if not isinstance(data, dict):
+                raise TypeError("parse_obj expects a dict")
+            return cls(**data)
+
+        def copy(self, *args, **kwargs):  # pragma: no cover - minimal helper
+            return self.__class__(**self.dict())
+
+    def Field(default=None, default_factory=None, **_kwargs):  # pragma: no cover
+        if default_factory is not None:
+            return default_factory()
+        return default
+
+    class ValidationError(Exception):
+        pass
+
+    pydantic_stub.BaseModel = BaseModel
+    pydantic_stub.Field = Field
+    pydantic_stub.ValidationError = ValidationError
+    sys.modules["pydantic"] = pydantic_stub
+
+if "yaml" not in sys.modules:
+    yaml_stub = ModuleType("yaml")
+    yaml_stub.safe_load = lambda stream: {}
+    sys.modules["yaml"] = yaml_stub
+
+from app import main
+from app.conversation import ConversationStore
+
+
+def _fake_execute_query(plan: Dict[str, Any], utterance: str, *, intent_engine: str) -> Dict[str, Any]:
+    return {
+        "answer": "stub",
+        "table": [],
+        "chart": None,
+        "sql": "SELECT 1",
+        "plan": plan,
+        "engine": intent_engine,
+        "runtime_ms": 0,
+        "rowcount": 0,
+        "warnings": [],
+        "lineage": {},
+        "nql": plan.get("_nql"),
+    }
+
+
+def _stub_plan() -> Dict[str, Any]:
+    return {
+        "_nql": {
+            "dimensions": [],
+            "group_by": [],
+            "filters": [],
+            "time": {"window": {}},
+        }
+    }
+
+
+def _reset_state(monkeypatch) -> None:
+    monkeypatch.setattr(main, "_conversations", ConversationStore(), raising=False)
+    monkeypatch.setattr(main, "build_plan", lambda utterance, prefer_llm=True: _stub_plan())
+    monkeypatch.setattr(main, "_execute_query", _fake_execute_query)
+    monkeypatch.setattr(main, "get_last_nql_status", lambda: {"attempted": True, "valid": True})
+
+
+def test_chat_complete_attempts_nql_when_enabled(monkeypatch):
+    _reset_state(monkeypatch)
+    monkeypatch.setenv("USE_NQL", "true")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "gpt-4")
+    monkeypatch.setenv("LLM_API_KEY", "sk-test")
+
+    payload = main.ChatCompleteRequest(session_id="demo", utterance="Show incidents")
+    response = main.chat_complete(payload, x_session_id="demo")
+
+    assert response["nql_status"]["attempted"] is True
+
+
+def test_chat_complete_gate_respects_flag(monkeypatch):
+    _reset_state(monkeypatch)
+    monkeypatch.setenv("USE_NQL", "false")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "gpt-4")
+    monkeypatch.setenv("LLM_API_KEY", "sk-test")
+
+    payload = main.ChatCompleteRequest(session_id="demo", utterance="Show incidents")
+    response = main.chat_complete(payload, x_session_id="demo")
+
+    assert response["nql_status"]["attempted"] is False
+    assert response["nql_status"]["reason"] == "use_nql_flag_false"


### PR DESCRIPTION
## Summary
- log the NQL gate configuration at startup, expose a /chat/debug-nql snapshot, and ensure chat responses include structured gate and fallback metadata
- read the USE_NQL flag at runtime and update the planner to honour the dynamic flag state
- add tests that cover NQL attempts when enabled and the flag-off gate behaviour

## Testing
- pytest nl-poc/tests/test_nql_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68de967332ec832ea3a209fa63496667