### PR TITLE
Add parser for natural language time expressions

### DIFF
--- a/nl-poc/app/time_expression_parser.py
+++ b/nl-poc/app/time_expression_parser.py
@@ -1,0 +1,184 @@
+"""Convert natural language time expressions into concrete date ranges."""
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timedelta
+from typing import Dict, Optional
+
+from .time_utils import current_date
+
+
+_LAST_WEEKS_PATTERN = re.compile(r"\blast\s+(?P<count>\d{1,2})\s+weeks?\b", re.IGNORECASE)
+_QUARTER_PATTERN = re.compile(
+    r"\b(?:q(?P<q1>[1-4])\s*(?P<year1>[12]\d{3})|(?P<year2>[12]\d{3})\s*[-\/]?\s*q(?P<q2>[1-4]))\b",
+    re.IGNORECASE,
+)
+_MONTH_ONLY_PATTERN = re.compile(r"^\s*(?P<year>[12]\d{3})[-/](?P<month>0[1-9]|1[0-2])\s*$")
+_YEAR_ONLY_PATTERN = re.compile(r"^\s*(?P<year>[12]\d{3})\s*$")
+_SINCE_PATTERN = re.compile(r"\bsince\s+(?P<rest>.+)", re.IGNORECASE)
+
+
+def _start_of_current_month(day: date) -> date:
+    return day.replace(day=1)
+
+
+def _start_of_previous_month(day: date) -> date:
+    if day.month == 1:
+        return date(day.year - 1, 12, 1)
+    return date(day.year, day.month - 1, 1)
+
+
+def _add_months(anchor: date, months: int) -> date:
+    year = anchor.year + ((anchor.month - 1 + months) // 12)
+    month = (anchor.month - 1 + months) % 12 + 1
+    return date(year, month, 1)
+
+
+def _format_chip_date(day: date) -> str:
+    return day.strftime("%b %d").replace(" 0", " ")
+
+
+def _parse_since_date(raw_text: str, today: date) -> date:
+    cleaned = raw_text.strip()
+    cleaned = re.sub(r"(\d+)(st|nd|rd|th)", r"\1", cleaned, flags=re.IGNORECASE)
+    cleaned = cleaned.replace(",", " ")
+    formats_with_year = [
+        "%Y-%m-%d",
+        "%Y/%m/%d",
+        "%B %d %Y",
+        "%b %d %Y",
+        "%m/%d/%Y",
+        "%m/%d/%y",
+        "%d %B %Y",
+        "%d %b %Y",
+    ]
+    for fmt in formats_with_year:
+        try:
+            parsed = datetime.strptime(cleaned, fmt).date()
+            return parsed
+        except ValueError:
+            continue
+
+    formats_without_year = ["%B %d", "%b %d", "%m/%d", "%d %B", "%d %b"]
+    for fmt in formats_without_year:
+        try:
+            parsed = datetime.strptime(cleaned, fmt)
+            candidate = date(today.year, parsed.month, parsed.day)
+            if candidate > today:
+                candidate = date(today.year - 1, parsed.month, parsed.day)
+            return candidate
+        except ValueError:
+            continue
+    raise ValueError(f"Could not parse date from '{raw_text}'")
+
+
+def _build_chip(expression: str, start: date, end: date, include_expression: bool) -> str:
+    start_str = _format_chip_date(start)
+    end_str = _format_chip_date(end)
+    if include_expression:
+        return f"{expression} = {start_str} → {end_str} (exclusive)"
+    return f"{start_str} → {end_str} (exclusive)"
+
+
+def parse_time_expression(expression: str, today: Optional[date] = None) -> Dict[str, str]:
+    """Convert a natural language time expression into a concrete JSON-friendly range."""
+
+    if not expression or not expression.strip():
+        raise ValueError("expression must be a non-empty string")
+
+    today = today or current_date()
+    normalized = expression.strip()
+    lowered = normalized.lower()
+
+    # last month
+    if re.search(r"\blast\s+month\b", lowered):
+        start = _start_of_previous_month(today)
+        end = _start_of_current_month(today)
+        chips = _build_chip(normalized, start, end, include_expression=False)
+        return {
+            "expression": normalized,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "chips": chips,
+        }
+
+    # last N weeks
+    match_weeks = _LAST_WEEKS_PATTERN.search(lowered)
+    if match_weeks:
+        count = int(match_weeks.group("count"))
+        if count <= 0:
+            raise ValueError("Number of weeks must be positive")
+        end = today
+        start = today - timedelta(weeks=count)
+        chips = _build_chip(normalized, start, end, include_expression=False)
+        return {
+            "expression": normalized,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "chips": chips,
+        }
+
+    # since <date>
+    match_since = _SINCE_PATTERN.search(lowered)
+    if match_since:
+        raw_date = expression[match_since.start("rest"):]
+        start = _parse_since_date(raw_date, today)
+        end = today
+        chips = _build_chip(normalized, start, end, include_expression=False)
+        return {
+            "expression": normalized,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "chips": chips,
+        }
+
+    # Quarter like Q1 2024 or 2024 Q1
+    match_quarter = _QUARTER_PATTERN.search(expression)
+    if match_quarter:
+        if match_quarter.group("q1") and match_quarter.group("year1"):
+            quarter = int(match_quarter.group("q1"))
+            year = int(match_quarter.group("year1"))
+        else:
+            quarter = int(match_quarter.group("q2"))
+            year = int(match_quarter.group("year2"))
+        start_month = (quarter - 1) * 3 + 1
+        start = date(year, start_month, 1)
+        end = _add_months(start, 3)
+        chips = _build_chip(normalized, start, end, include_expression=True)
+        return {
+            "expression": normalized,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "chips": chips,
+        }
+
+    # Month like 2024-06
+    match_month = _MONTH_ONLY_PATTERN.match(normalized)
+    if match_month:
+        year = int(match_month.group("year"))
+        month = int(match_month.group("month"))
+        start = date(year, month, 1)
+        end = _add_months(start, 1)
+        chips = _build_chip(normalized, start, end, include_expression=True)
+        return {
+            "expression": normalized,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "chips": chips,
+        }
+
+    # Year like 2023
+    match_year = _YEAR_ONLY_PATTERN.match(normalized)
+    if match_year:
+        year = int(match_year.group("year"))
+        start = date(year, 1, 1)
+        end = date(year + 1, 1, 1)
+        chips = _build_chip(normalized, start, end, include_expression=True)
+        return {
+            "expression": normalized,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "chips": chips,
+        }
+
+    raise ValueError(f"Unsupported time expression: '{expression}'")

--- a/nl-poc/tests/test_time_expression_parser.py
+++ b/nl-poc/tests/test_time_expression_parser.py
@@ -1,0 +1,87 @@
+from datetime import date
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.time_expression_parser import parse_time_expression
+
+
+@pytest.mark.parametrize(
+    "expression, today, expected",
+    [
+        (
+            "last month",
+            date(2025, 10, 2),
+            {
+                "start_date": "2025-09-01",
+                "end_date": "2025-10-01",
+                "chips": "Sep 1 → Oct 1 (exclusive)",
+            },
+        ),
+        (
+            "Q1 2024",
+            date(2025, 10, 2),
+            {
+                "start_date": "2024-01-01",
+                "end_date": "2024-04-01",
+                "chips": "Q1 2024 = Jan 1 → Apr 1 (exclusive)",
+            },
+        ),
+        (
+            "last 8 weeks",
+            date(2025, 10, 2),
+            {
+                "start_date": "2025-08-07",
+                "end_date": "2025-10-02",
+                "chips": "Aug 7 → Oct 2 (exclusive)",
+            },
+        ),
+        (
+            "since Jan 15",
+            date(2025, 10, 2),
+            {
+                "start_date": "2025-01-15",
+                "end_date": "2025-10-02",
+                "chips": "Jan 15 → Oct 2 (exclusive)",
+            },
+        ),
+        (
+            "2023",
+            date(2025, 10, 2),
+            {
+                "start_date": "2023-01-01",
+                "end_date": "2024-01-01",
+                "chips": "2023 = Jan 1 → Jan 1 (exclusive)",
+            },
+        ),
+        (
+            "2024-06",
+            date(2025, 10, 2),
+            {
+                "start_date": "2024-06-01",
+                "end_date": "2024-07-01",
+                "chips": "2024-06 = Jun 1 → Jul 1 (exclusive)",
+            },
+        ),
+    ],
+)
+def test_parse_time_expression(expression, today, expected):
+    result = parse_time_expression(expression, today=today)
+    assert result["expression"] == expression
+    assert result["start_date"] == expected["start_date"]
+    assert result["end_date"] == expected["end_date"]
+    assert result["chips"] == expected["chips"]
+
+
+@pytest.mark.parametrize(
+    "expression",
+    ["", "   ", "next decade"],
+)
+def test_parse_time_expression_invalid(expression):
+    with pytest.raises(ValueError):
+        parse_time_expression(expression, today=date(2025, 10, 2))


### PR DESCRIPTION
## Summary
- add a parser that converts supported natural language time expressions into absolute ISO date ranges with readable chips
- add unit coverage for parsing months, quarters, rolling weeks, "since" expressions, and whole-year ranges

## Testing
- pytest nl-poc/tests/test_time_expression_parser.py -q

------
https://chatgpt.com/codex/tasks/task_e_68df2936ca50832eb360315fea92e1ac