### PR TITLE
Fix header dimension, compare detection, and count aggregate support

### DIFF
--- a/nl-poc/app/nql/model.py
+++ b/nl-poc/app/nql/model.py
@@ -119,6 +119,7 @@ FilterType = Literal["text", "text_raw", "number", "date", "category"]
 TimeGrain = Literal["day", "week", "month", "quarter", "year"]
 WindowType = Literal["single_month", "absolute", "quarter", "relative_months", "ytd"]
 CompareType = Literal["mom", "yoy", "wow", "dod"]
+CompareMode = Literal["time", "dimension", "metric"]
 CompareBaseline = Literal["previous_period", "same_period_last_year"]
 SortDirection = Literal["asc", "desc"]
 
@@ -171,9 +172,13 @@ class CompareInternalWindow(BaseModel):
 
 
 class CompareSpec(BaseModel):
-    type: CompareType
+    type: Optional[CompareType] = None
     baseline: Optional[CompareBaseline] = None
     internal_window: Optional[CompareInternalWindow] = None
+    mode: Optional[CompareMode] = None
+    lhs_time: Optional[str] = None
+    rhs_time: Optional[str] = None
+    dimension: Optional[str] = None
 
     class Config:
         extra = "forbid"
@@ -215,6 +220,7 @@ class NQLQuery(BaseModel):
     intent: IntentType
     dataset: str
     metrics: List[Metric]
+    aggregate: Optional[MetricAgg] = None
     time: TimeSpec
     dimensions: List[str] = Field(default_factory=list)
     filters: List[Filter] = Field(default_factory=list)

--- a/nl-poc/app/time_utils.py
+++ b/nl-poc/app/time_utils.py
@@ -265,7 +265,7 @@ def parse_year(text: str) -> Optional[TimeRange]:
                 today = current_date()
                 end = _next_month(date(end_year, min(today.month, 12), 1))
             else:
-                end = date(end_year, 12, 31)
+                end = date(end_year + 1, 1, 1)
 
             label = f"{start_year}-{end_year}" if not ytd_after else f"{start_year} vs {end_year} YTD"
             return TimeRange(start=start, end=end, label=label)
@@ -273,7 +273,7 @@ def parse_year(text: str) -> Optional[TimeRange]:
     # prefer the last occurrence to capture more specific context like "in 2023"
     year = int(matches[-1].group(1))
     start = date(year, 1, 1)
-    end = date(year, 12, 31)
+    end = date(year + 1, 1, 1)
     return TimeRange(start=start, end=end, label=str(year))
 
 

--- a/nl-poc/tests/test_bottom_query_header.py
+++ b/nl-poc/tests/test_bottom_query_header.py
@@ -7,6 +7,22 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from app.viz import build_narrative
 
 
+def test_header_uses_current_group_by_dimension():
+    plan = {
+        "metrics": ["incidents"],
+        "group_by": ["premise"],
+        "order_by": [{"field": "incidents", "dir": "desc"}],
+    }
+    records = [
+        {"premise": "RESIDENCE", "incidents": 5},
+        {"premise": "RESTAURANT", "incidents": 3},
+    ]
+
+    narrative = build_narrative(plan, records)
+
+    assert "RESIDENCE led with 5 incidents" in narrative
+
+
 def test_bottom_query_uses_fewest():
     """Test that bottom queries use 'had the fewest' instead of 'led with'."""
 

--- a/nl-poc/tests/test_compare_vs_intent.py
+++ b/nl-poc/tests/test_compare_vs_intent.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.planner import build_plan_rule_based
+
+
+def test_compare_year_vs_year_sets_time_mode():
+    plan = build_plan_rule_based("Compare assaults in 2023 vs 2024")
+    compare = plan.get("compare")
+    assert compare is not None
+    assert compare.get("mode") == "time"
+    assert compare.get("lhs_time") == "2023-01-01/2024-01-01"
+    assert compare.get("rhs_time") == "2024-01-01/2025-01-01"
+
+
+def test_compare_quarter_vs_quarter_sets_time_mode():
+    plan = build_plan_rule_based("Compare incidents Q1 2024 vs Q1 2023")
+    compare = plan.get("compare")
+    assert compare is not None
+    assert compare.get("mode") == "time"
+    assert compare.get("lhs_time") == "2024-01-01/2024-04-01"
+    assert compare.get("rhs_time") == "2023-01-01/2023-04-01"
+
+
+def test_compare_dimension_values_detects_dimension_mode():
+    plan = build_plan_rule_based("Compare assaults in Hollywood vs Wilshire in 2024")
+    compare = plan.get("compare")
+    assert compare is not None
+    assert compare.get("mode") == "dimension"
+    assert compare.get("dimension") == "area"
+    diagnostics = (plan.get("extras") or {}).get("diagnostics", [])
+    assert any(d.get("type") == "ambiguous_compare" for d in diagnostics)
+
+
+def test_ambiguous_compare_returns_diagnostic():
+    plan = build_plan_rule_based("Compare assaults in 2023 vs Hollywood")
+    diagnostics = (plan.get("extras") or {}).get("diagnostics", [])
+    assert any(d.get("type") == "ambiguous_compare" for d in diagnostics)
+    compare = plan.get("compare")
+    assert compare is not None
+    assert compare.get("mode") == "dimension"

--- a/nl-poc/tests/test_count_aggregate.py
+++ b/nl-poc/tests/test_count_aggregate.py
@@ -1,0 +1,73 @@
+import sys
+from datetime import date
+from pathlib import Path
+from types import ModuleType
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+if "yaml" not in sys.modules:
+    yaml_stub = ModuleType("yaml")
+    yaml_stub.safe_load = lambda stream: {}
+    sys.modules["yaml"] = yaml_stub
+
+if "duckdb" not in sys.modules:
+    duckdb_stub = ModuleType("duckdb")
+    duckdb_stub.connect = lambda path: None
+    duckdb_stub.DuckDBPyConnection = object
+    duckdb_stub.Error = Exception
+    sys.modules["duckdb"] = duckdb_stub
+
+from app.planner import build_plan_rule_based
+from app.resolver import PlanResolver, SemanticModel, SemanticDimension, SemanticMetric
+from app.sql_builder import build as build_sql
+
+
+class _ExecutorStub:
+    def find_closest_value(self, dimension, value):
+        return value
+
+    def closest_matches(self, dimension, value, limit: int = 5):  # pragma: no cover - not used
+        return []
+
+    def parse_date(self, value: str) -> date:
+        return date.fromisoformat(value)
+
+
+def _semantic_model() -> SemanticModel:
+    return SemanticModel(
+        table="la_crime_raw",
+        date_grain="month",
+        dimensions={
+            "month": SemanticDimension(name="month", column="DATE OCC"),
+            "area": SemanticDimension(name="area", column="AREA NAME"),
+            "weapon": SemanticDimension(name="weapon", column="Weapon Desc"),
+        },
+        metrics={
+            "incidents": SemanticMetric(name="incidents", agg="count", grain=["month"]),
+        },
+    )
+
+
+def test_how_many_incidents_sets_count_aggregate():
+    plan = build_plan_rule_based("How many incidents citywide?")
+    assert plan.get("aggregate") == "count"
+    assert plan.get("metrics") == ["incidents"]
+
+
+def test_count_by_area_uses_count_metric():
+    plan = build_plan_rule_based("count by area in 2024")
+    assert plan.get("aggregate") == "count"
+    assert plan.get("group_by") == ["area"]
+    assert plan.get("metrics") == ["count"]
+
+    resolver = PlanResolver(_semantic_model(), _ExecutorStub())
+    resolved = resolver.resolve(plan)
+    sql = build_sql(resolved, _semantic_model())
+    assert "COUNT(*) AS count" in sql
+
+
+def test_number_of_stabbings_adds_weapon_filter():
+    plan = build_plan_rule_based("number of stabbings last month")
+    assert plan.get("aggregate") == "count"
+    filters = plan.get("filters") or []
+    assert any(f.get("field") == "weapon" for f in filters)


### PR DESCRIPTION
## Summary
- adjust narrative header logic to pull labels from the current group_by column and default to a metric-only header when no grouping is present
- add rule-based detection for "compare ... vs ..." requests, wiring through new compare metadata and a count aggregate heuristic, plus parser support for exclusive year ends
- extend the NQL schema, compiler, resolver, and SQL builder to understand aggregate=count and compare modes, with new regression tests covering count intents and compare variants

## Testing
- `pytest nl-poc/tests/test_bottom_query_header.py nl-poc/tests/test_compare_vs_intent.py nl-poc/tests/test_count_aggregate.py nl-poc/tests/nql/test_nql_compiler.py`
- `PYTHONPATH=nl-poc pytest nl-poc/tests/test_time_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68df33a4dd40832eb4def9702d127c60