### PR TITLE
Fix header selection for grouped results and normalize single-month ranges

### DIFF
--- a/nl-poc/app/viz.py
+++ b/nl-poc/app/viz.py
@@ -1,6 +1,5 @@
 """Chart specification helpers."""
 from __future__ import annotations
-
 from typing import Dict, List
 
 
@@ -30,82 +29,139 @@ def choose_chart(plan: Dict[str, object], records: List[Dict[str, object]]) -> D
 
 def build_narrative(plan: Dict[str, object], records: List[Dict[str, object]]) -> str:
     if not records:
-        return "No data matched the request."
+        return "No incidents found for the selected period."
 
-    metric = plan.get("metrics", ["incidents"])[0]
     compare = plan.get("compare")
+    compile_info = {}
+    extras = plan.get("extras") or {}
+    if isinstance(plan.get("compileInfo"), dict):
+        compile_info = plan["compileInfo"]
+    elif isinstance(extras.get("compileInfo"), dict):
+        compile_info = extras["compileInfo"]
 
-    # For comparison queries, find the record with the highest change_pct
-    # instead of just using records[0] (which may be sorted by incidents)
+    def _first_entry(value):
+        if isinstance(value, (list, tuple)):
+            return value[0] if value else None
+        return value
+
+    dim = _first_entry(compile_info.get("groupBy"))
+    if dim is None:
+        dim = _first_entry(plan.get("group_by") or [])
+
+    metric_alias = compile_info.get("metricAlias")
+    metrics = plan.get("metrics") or []
+    if not metric_alias and metrics:
+        metric_alias = metrics[0]
+
+    def _first_numeric_column(rows: List[Dict[str, object]], exclude: set) -> str:
+        for row in rows:
+            for key, value in row.items():
+                if key in exclude:
+                    continue
+                if isinstance(value, bool):
+                    continue
+                if isinstance(value, (int, float)):
+                    return key
+        return ""
+
+    exclude_keys = {dim, "change_pct", "change_pct_formatted"}
+    metric_key = metric_alias or _first_numeric_column(records, {k for k in exclude_keys if k}) or "count"
+
+    order_by = plan.get("order_by", [])
+    is_ascending = any(
+        isinstance(o, dict) and o.get("dir") == "asc"
+        for o in order_by
+    )
+
+    selected_by_change = False
     if compare and any("change_pct" in rec for rec in records):
-        # Filter to records with non-null change_pct and find max
         records_with_change = [r for r in records if r.get("change_pct") is not None]
         if records_with_change:
             top = max(records_with_change, key=lambda r: r.get("change_pct", float("-inf")))
+            selected_by_change = True
         else:
             top = records[0]
     else:
         top = records[0]
 
-    parts = []
-    group_by = plan.get("group_by") or []
-    if group_by:
-        metric_candidates = plan.get("metrics") or []
-        metric_alias = metric_candidates[0] if metric_candidates else metric
+    sorted_locally = False
+    if dim and not selected_by_change:
+        def _metric_value(row: Dict[str, object]) -> float:
+            value = row.get(metric_key)
+            if isinstance(value, bool) or value is None:
+                return float("inf") if is_ascending else float("-inf")
+            if isinstance(value, (int, float)):
+                return float(value)
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return float("inf") if is_ascending else float("-inf")
 
-        label = "Unknown"
-        resolved_dim = None
-        for dim in group_by:
-            if isinstance(dim, dict):
-                dim_keys = [
-                    dim.get("alias"),
-                    dim.get("field"),
-                    dim.get("expr"),
-                ]
-            else:
-                dim_keys = [dim]
-            resolved_dim = next((key for key in dim_keys if key and key in top), None)
-            if resolved_dim:
-                label = top.get(resolved_dim, "Unknown")
-                break
-        if not resolved_dim:
-            resolved_dim = next(
-                (
-                    key
-                    for key in top.keys()
-                    if key not in metric_candidates and key not in {metric, "change_pct"}
-                ),
-                None,
-            )
-            if resolved_dim:
-                label = top.get(resolved_dim, "Unknown")
-
-        value = top.get(metric_alias if metric_alias in top else metric)
-        if value is None:
-            value = top.get(metric)
-
-        # Check if this is a "bottom/lowest" query (ascending sort order)
-        order_by = plan.get("order_by", [])
-        is_ascending = any(
-            isinstance(o, dict) and o.get("dir") == "asc"
-            for o in order_by
-        )
+        def _dim_label(row: Dict[str, object]) -> str:
+            label_value = row.get(dim)
+            if label_value is None:
+                return ""
+            return str(label_value)
 
         if is_ascending:
-            parts.append(f"{label} had the fewest with {value} incidents")
+            sorted_rows = sorted(
+                records,
+                key=lambda r: (_metric_value(r), _dim_label(r)),
+            )
         else:
-            parts.append(f"{label} led with {value} incidents")
+            sorted_rows = sorted(
+                records,
+                key=lambda r: (-_metric_value(r), _dim_label(r)),
+            )
+        if sorted_rows:
+            sorted_locally = sorted_rows[0] is not records[0]
+            top = sorted_rows[0]
+
+    parts: List[str] = []
+
+    if dim:
+        label_value = top.get(dim, "Unknown")
+        if label_value in (None, ""):
+            label = "Unknown"
+        else:
+            label = str(label_value)
+        metric_value = top.get(metric_key)
+        if metric_value is None:
+            metric_value = 0
+        if is_ascending:
+            parts.append(f"{label} had the fewest with {metric_value} incidents")
+        else:
+            parts.append(f"{label} led with {metric_value} incidents")
     else:
-        metric_name = metric.replace("_", " ")
-        value = top.get(metric)
-        if value is None and plan.get("metrics"):
-            fallback_metric = plan["metrics"][0]
-            value = top.get(fallback_metric)
-        parts.append(f"Total {metric_name} was {value}")
+        metric_name = (metric_key or "count").replace("_", " ")
+        total_row = top
+        metric_value = total_row.get(metric_key)
+        if metric_value is None:
+            metric_value = 0
+        parts.append(f"Total {metric_name}: {metric_value}")
 
     if compare and "change_pct" in top and top["change_pct"] is not None:
         direction = "up" if top["change_pct"] > 0 else "down"
-        pct_value = abs(round(top['change_pct'], 1))  # SQL already multiplied by 100
+        pct_raw = top["change_pct"]
+        if isinstance(pct_raw, (int, float)):
+            scaled = pct_raw * 100 if -1 < pct_raw < 1 else pct_raw
+        else:
+            try:
+                pct_numeric = float(pct_raw)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                pct_numeric = 0
+            scaled = pct_numeric * 100 if -1 < pct_numeric < 1 else pct_numeric
+        pct_value = abs(round(scaled, 1))
         parts.append(f"({direction} {pct_value}% vs prior period)")
+
+    if sorted_locally:
+        diagnostics = plan.setdefault("diagnostics", [])
+        if not any(d.get("type") == "header_local_sort" for d in diagnostics if isinstance(d, dict)):
+            diagnostics.append(
+                {
+                    "type": "header_local_sort",
+                    "message": "Rows locally sorted by metric desc for header consistency",
+                }
+            )
 
     return "; ".join(parts) + "."

--- a/nl-poc/tests/nql/test_nql_compiler.py
+++ b/nl-poc/tests/nql/test_nql_compiler.py
@@ -61,16 +61,23 @@ def _load_fixture(name: str) -> dict:
         return json.load(f)
 
 
-def test_single_month_equality_filter():
+def test_single_month_range_filter():
     payload = _load_fixture("single_month.json")
     compiled = compile_payload(payload)
     plan = compiled.plan
     assert plan["filters"] == [
-        {"field": "month", "op": "=", "value": "2023-06-01"}
+        {
+            "field": "month",
+            "op": "between",
+            "value": ["2023-06-01", "2023-07-01"],
+        }
     ]
     assert plan["limit"] == 100
     assert plan["extras"]["rowcap_hint"] == 2000
-    assert "single_month_equality" in plan["_critic_pass"]
+    assert "single_month_equality" not in plan["_critic_pass"]
+    compile_info = plan.get("compileInfo") or {}
+    assert compile_info.get("metricAlias") == "incidents"
+    assert compile_info.get("groupBy") == []
 
 
 def test_quarter_window_enforces_exclusive_end():

--- a/nl-poc/tests/test_header_top_group.py
+++ b/nl-poc/tests/test_header_top_group.py
@@ -1,0 +1,58 @@
+"""Tests for header selection logic using validated result rows."""
+from pathlib import Path
+import sys
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.viz import build_narrative  # noqa: E402
+
+
+def _base_plan():
+    return {
+        "metrics": ["count"],
+        "group_by": ["premise"],
+        "order_by": [{"field": "count", "dir": "desc"}],
+        "compileInfo": {"metricAlias": "count", "groupBy": ["premise"]},
+    }
+
+
+def test_header_uses_top_group_from_sorted_rows():
+    plan = _base_plan()
+    rows = [
+        {"premise": "STREET", "count": 254},
+        {"premise": "SINGLE FAMILY DWELLING", "count": 45},
+        {"premise": "VEHICLE, PASSENGER/TRUCK", "count": 32},
+    ]
+
+    narrative = build_narrative(plan, rows)
+
+    assert narrative == "STREET led with 254 incidents."
+
+
+def test_header_sorts_rows_locally_when_needed():
+    plan = _base_plan()
+    rows = [
+        {"premise": "VEHICLE, PASSENGER/TRUCK", "count": 32},
+        {"premise": "STREET", "count": 254},
+        {"premise": "SINGLE FAMILY DWELLING", "count": 45},
+    ]
+
+    narrative = build_narrative(plan, rows)
+
+    assert narrative == "STREET led with 254 incidents."
+    diagnostics = plan.get("diagnostics", [])
+    assert any(d.get("type") == "header_local_sort" for d in diagnostics)
+
+
+def test_metric_only_falls_back_to_total_header():
+    plan = {
+        "metrics": ["incidents"],
+        "group_by": [],
+        "compileInfo": {"metricAlias": "incidents", "groupBy": []},
+    }
+    rows = [{"incidents": 254}]
+
+    narrative = build_narrative(plan, rows)
+
+    assert narrative == "Total incidents: 254."


### PR DESCRIPTION
## Summary
- update narrative header generation to rely on validated result rows, fall back for metric-only responses, and emit a diagnostic when local sorting is required
- remove the legacy single-month equality validator, compile single-month windows as start-inclusive/end-exclusive ranges, and surface compile metadata for headers
- extend the resolver to recognise range-based single-month filters and add targeted unit tests covering the new header logic and validator behaviour

## Testing
- pytest nl-poc/tests/test_header_top_group.py nl-poc/tests/nql/test_nql_compiler.py
- pytest nl-poc/tests/test_bottom_query_header.py nl-poc/tests/test_mom_header_leader.py


------
https://chatgpt.com/codex/tasks/task_e_68e2d64ecba0832eb0591cf159ad8512