### PR TITLE
Fix month parsing and add count support

### DIFF
--- a/nl-poc/app/main.py
+++ b/nl-poc/app/main.py
@@ -347,10 +347,15 @@ def _execute_query(plan: Dict[str, Any], utterance: str, *, intent_engine: str) 
     if rowcap_warning:
         warnings.append(rowcap_warning)
 
-    metric_defs = {
-        metric: semantic.metrics[metric].sql_expression()
-        for metric in resolved_plan.get("metrics", [])
-    }
+    resolved_metrics = [metric for metric in resolved_plan.get("metrics", []) if isinstance(metric, str)]
+    aggregate = resolved_plan.get("aggregate")
+    if aggregate == "count" or any(metric in {"*", "count"} for metric in resolved_metrics):
+        metric_defs = {"count": "COUNT(*)"}
+    else:
+        metric_defs = {
+            metric: semantic.metrics[metric].sql_expression()
+            for metric in resolved_metrics
+        }
 
     response = {
         "answer": narrative,

--- a/nl-poc/app/nql/model.py
+++ b/nl-poc/app/nql/model.py
@@ -113,7 +113,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for lightweight test 
 
 
 IntentType = Literal["aggregate", "detail", "trend", "compare", "rank", "distribution"]
-MetricAgg = Literal["count", "sum", "avg", "min", "max", "distinct_count"]
+MetricAgg = Literal["count", "sum", "avg", "min", "max", "distinct_count", "count_distinct"]
 FilterOp = Literal["=", "!=", ">", ">=", "<", "<=", "between", "in", "not_in", "like", "like_any", "ilike", "regex"]
 FilterType = Literal["text", "text_raw", "number", "date", "category"]
 TimeGrain = Literal["day", "week", "month", "quarter", "year"]

--- a/nl-poc/app/rewriter/__init__.py
+++ b/nl-poc/app/rewriter/__init__.py
@@ -1,0 +1,3 @@
+from .canonicalize_metric import canonicalize_metric
+
+__all__ = ["canonicalize_metric"]

--- a/nl-poc/app/rewriter/canonicalize_metric.py
+++ b/nl-poc/app/rewriter/canonicalize_metric.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+from ..synonyms import SynonymBundle
+
+
+_COUNT_INTENT_RE = re.compile(r"\b(?:how many|count|number of)\b", re.IGNORECASE)
+
+
+def _detect_domain_metric(question: str, bundle: SynonymBundle) -> str | None:
+    lowered = question.lower()
+    for token, canonical in bundle.metric_aliases.items():
+        if re.search(rf"\b{re.escape(token)}\b", lowered):
+            return canonical
+    return None
+
+
+def canonicalize_metric(question: str, plan: Dict[str, object], bundle: SynonymBundle) -> Dict[str, object]:
+    """Normalise metric selections for count intents."""
+
+    if not isinstance(plan, dict):
+        return plan
+    if not _COUNT_INTENT_RE.search(question):
+        return plan
+
+    metrics = plan.get("metrics") or []
+    metrics = [metric for metric in metrics if isinstance(metric, str)]
+    domain_metric = next((metric for metric in metrics if metric not in {"count", "*"}), None)
+    if not domain_metric:
+        domain_metric = _detect_domain_metric(question, bundle)
+
+    updated_metrics: List[str]
+    extras = plan.get("extras")
+    diagnostics: List[Dict[str, object]] = []
+    if isinstance(extras, dict):
+        diagnostics = [diag for diag in extras.get("diagnostics", []) if isinstance(diag, dict)]
+    existing_diag_keys = {(diag.get("type"), diag.get("message")) for diag in diagnostics}
+
+    if domain_metric:
+        updated_metrics = [domain_metric]
+    else:
+        updated_metrics = ["*"]
+        fallback_entry = (
+            "unknown_metric_fallback",
+            "Using row count for 'count' intent",
+        )
+        if fallback_entry not in existing_diag_keys:
+            diagnostics.append(
+                {
+                    "type": fallback_entry[0],
+                    "message": fallback_entry[1],
+                }
+            )
+
+    plan["metrics"] = updated_metrics
+    plan["aggregate"] = "count"
+
+    if diagnostics:
+        extras = extras or {}
+        extras["diagnostics"] = diagnostics
+        plan["extras"] = extras
+
+    return plan

--- a/nl-poc/tests/nql/test_nql_compiler.py
+++ b/nl-poc/tests/nql/test_nql_compiler.py
@@ -16,7 +16,7 @@ if "yaml" not in sys.modules:
 
 if "duckdb" not in sys.modules:
     duckdb_stub = ModuleType("duckdb")
-    duckdb_stub.connect = lambda path: None
+    duckdb_stub.connect = lambda path, **kwargs: None
     duckdb_stub.DuckDBPyConnection = object
     duckdb_stub.Error = Exception
     sys.modules["duckdb"] = duckdb_stub

--- a/nl-poc/tests/test_api_response_metadata.py
+++ b/nl-poc/tests/test_api_response_metadata.py
@@ -6,7 +6,7 @@ import pytest
 
 if "duckdb" not in sys.modules:
     duckdb_stub = ModuleType("duckdb")
-    duckdb_stub.connect = lambda path: None
+    duckdb_stub.connect = lambda path, **kwargs: None
     duckdb_stub.DuckDBPyConnection = object
     duckdb_stub.Error = Exception
     sys.modules["duckdb"] = duckdb_stub
@@ -47,6 +47,7 @@ if "fastapi" not in sys.modules:
 
     fastapi_stub.FastAPI = FastAPI
     fastapi_stub.HTTPException = HTTPException
+    fastapi_stub.Header = lambda *args, **kwargs: None
     sys.modules["fastapi"] = fastapi_stub
 
     middleware_module = ModuleType("fastapi.middleware")

--- a/nl-poc/tests/test_canonicalize_metric.py
+++ b/nl-poc/tests/test_canonicalize_metric.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import sys
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.rewriter.canonicalize_metric import canonicalize_metric
+from app.synonyms import load_synonyms
+
+
+@pytest.fixture(scope="module")
+def bundle():
+    return load_synonyms()
+
+
+def test_canonicalize_metric_preserves_domain_metric(bundle):
+    plan = {"metrics": ["count"], "group_by": [], "filters": []}
+    result = canonicalize_metric("How many incidents citywide?", plan, bundle)
+    assert result["metrics"] == ["incidents"]
+    assert result["aggregate"] == "count"
+
+
+def test_canonicalize_metric_sets_row_count(bundle):
+    plan = {"metrics": ["count"], "group_by": ["area"], "filters": []}
+    result = canonicalize_metric("count by area in 2024", plan, bundle)
+    assert result["metrics"] == ["*"]
+    assert result["aggregate"] == "count"
+    assert result["group_by"] == ["area"]
+
+
+def test_canonicalize_metric_adds_fallback_diagnostic(bundle):
+    plan = {"metrics": ["count"], "filters": []}
+    result = canonicalize_metric("number of stabbings last month", plan, bundle)
+    assert result["aggregate"] == "count"
+    extras = result.get("extras", {})
+    diagnostics = extras.get("diagnostics", [])
+    assert any(diag.get("type") == "unknown_metric_fallback" for diag in diagnostics)

--- a/nl-poc/tests/test_executor_rowcap.py
+++ b/nl-poc/tests/test_executor_rowcap.py
@@ -33,7 +33,7 @@ if "duckdb" not in sys.modules:
         def execute(self, sql):
             return MockResult(self.num_rows)
 
-    duckdb_stub.connect = lambda path: MockConnection()
+    duckdb_stub.connect = lambda path, **kwargs: MockConnection()
     sys.modules["duckdb"] = duckdb_stub
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/nl-poc/tests/test_like_bug.py
+++ b/nl-poc/tests/test_like_bug.py
@@ -13,7 +13,7 @@ if "yaml" not in sys.modules:
 # Mock duckdb module
 if "duckdb" not in sys.modules:
     duckdb_stub = ModuleType("duckdb")
-    duckdb_stub.connect = lambda path: None
+    duckdb_stub.connect = lambda path, **kwargs: None
     duckdb_stub.DuckDBPyConnection = object
     duckdb_stub.Error = Exception
     sys.modules["duckdb"] = duckdb_stub

--- a/nl-poc/tests/test_like_filter_comprehensive.py
+++ b/nl-poc/tests/test_like_filter_comprehensive.py
@@ -13,7 +13,7 @@ if "yaml" not in sys.modules:
 # Mock duckdb module
 if "duckdb" not in sys.modules:
     duckdb_stub = ModuleType("duckdb")
-    duckdb_stub.connect = lambda path: None
+    duckdb_stub.connect = lambda path, **kwargs: None
     duckdb_stub.DuckDBPyConnection = object
     duckdb_stub.Error = Exception
     sys.modules["duckdb"] = duckdb_stub

--- a/nl-poc/tests/test_main_count_integration.py
+++ b/nl-poc/tests/test_main_count_integration.py
@@ -1,0 +1,181 @@
+from datetime import date
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+import sys
+
+import pytest
+
+# Provide minimal stubs for optional dependencies used by app.main imports
+if "yaml" not in sys.modules:
+    yaml_stub = ModuleType("yaml")
+    yaml_stub.safe_load = lambda stream: {}
+    sys.modules["yaml"] = yaml_stub
+
+if "duckdb" not in sys.modules:
+    duckdb_stub = ModuleType("duckdb")
+    duckdb_stub.connect = lambda path, **kwargs: None
+    duckdb_stub.DuckDBPyConnection = object
+    duckdb_stub.Error = Exception
+    sys.modules["duckdb"] = duckdb_stub
+
+if "fastapi" not in sys.modules:
+    fastapi_stub = ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class FastAPI:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def add_middleware(self, *args, **kwargs):
+            return None
+
+        def on_event(self, event):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def get(self, path):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def post(self, path):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    fastapi_stub.FastAPI = FastAPI
+    fastapi_stub.HTTPException = HTTPException
+    fastapi_stub.Header = lambda *args, **kwargs: None
+    sys.modules["fastapi"] = fastapi_stub
+
+    middleware_module = ModuleType("fastapi.middleware")
+    cors_module = ModuleType("fastapi.middleware.cors")
+
+    class CORSMiddleware:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    cors_module.CORSMiddleware = CORSMiddleware
+    middleware_module.cors = cors_module
+    sys.modules["fastapi.middleware"] = middleware_module
+    sys.modules["fastapi.middleware.cors"] = cors_module
+
+if "pydantic" not in sys.modules:
+    pydantic_stub = ModuleType("pydantic")
+
+    class BaseModel:  # pragma: no cover - simple stub
+        def __init__(self, **data):
+            for key, value in data.items():
+                setattr(self, key, value)
+
+    pydantic_stub.BaseModel = BaseModel
+    sys.modules["pydantic"] = pydantic_stub
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.executor import QueryResult
+from app.main import AskRequest, _state, ask
+from app.planner import build_plan_rule_based
+from app.resolver import PlanResolver, SemanticDimension, SemanticMetric, SemanticModel
+
+
+class _PlanResolver(PlanResolver):
+    def __init__(self, semantic, executor):
+        super().__init__(semantic, executor)
+        self.last_plan = None
+
+    def resolve(self, plan):
+        resolved = super().resolve(plan)
+        self.last_plan = resolved
+        return resolved
+
+
+class _ResolverExecutorStub:
+    def find_closest_value(self, dimension, value):
+        return value
+
+    def closest_matches(self, dimension, value, limit: int = 5):
+        return []
+
+    def parse_date(self, value: str) -> date:
+        return date.fromisoformat(value)
+
+
+class _QueryExecutorStub:
+    def __init__(self, records):
+        self._result = QueryResult(records=records, runtime_ms=7.5, rowcount=len(records))
+        self.queries = []
+
+    def query(self, sql):
+        self.queries.append(sql)
+        return self._result
+
+
+def _semantic_model() -> SemanticModel:
+    return SemanticModel(
+        table="la_crime_raw",
+        date_grain="month",
+        dimensions={
+            "month": SemanticDimension(name="month", column="DATE OCC"),
+            "area": SemanticDimension(name="area", column="AREA NAME"),
+            "weapon": SemanticDimension(name="weapon", column="Weapon Desc"),
+        },
+        metrics={
+            "incidents": SemanticMetric(name="incidents", agg="count", grain=["month"]),
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def restore_state():
+    original = _state.copy()
+    try:
+        yield
+    finally:
+        _state.clear()
+        _state.update(original)
+
+
+def test_hollywood_stabbings_count_flow(monkeypatch):
+    monkeypatch.setattr("app.main.build_plan", lambda question, prefer_llm: build_plan_rule_based(question))
+    monkeypatch.setattr("app.main.get_last_intent_engine", lambda: "rule_based")
+    monkeypatch.setattr("app.main.guardrails.enforce", lambda sql, plan: None)
+    monkeypatch.setattr("app.main.guardrails.check_rowcap_exceeded", lambda truncated: None)
+    monkeypatch.setattr("app.main.viz.choose_chart", lambda plan, records: {"type": "table", "data": []})
+    monkeypatch.setattr("app.main.viz.build_narrative", lambda plan, records: "Narrative")
+
+    semantic = _semantic_model()
+    resolver_executor = _ResolverExecutorStub()
+    resolver = _PlanResolver(semantic, resolver_executor)
+    query_executor = _QueryExecutorStub(records=[{"count": 5}])
+
+    monkeypatch.setitem(_state, "resolver", resolver)
+    monkeypatch.setitem(_state, "executor", query_executor)
+    monkeypatch.setitem(_state, "semantic", semantic)
+    monkeypatch.setitem(_state, "source_csv", "demo.csv")
+
+    response = ask(
+        AskRequest(question="How many stabbings happened in Hollywood in March 2023?")
+    )
+
+    assert response["rowcount"] == 1
+    assert query_executor.queries, "Expected SQL execution"
+    assert "COUNT(*) AS count" in query_executor.queries[0]
+
+    resolved_plan = resolver.last_plan or {}
+    month_filters = [f for f in resolved_plan.get("filters", []) if f.get("field") == "month"]
+    assert month_filters
+    month_filter = month_filters[0]
+    assert month_filter.get("value") == ["2023-03-01", "2023-04-01"]
+    assert resolved_plan.get("aggregate") == "count"

--- a/nl-poc/tests/test_mom_bug.py
+++ b/nl-poc/tests/test_mom_bug.py
@@ -22,7 +22,10 @@ compare = plan.get('compare')
 print(f"\nCompare: {compare}")
 
 # Verify
-assert any(f['field'] == 'month' and f['value'] == '2024-07-01' for f in filters), "Missing correct month filter"
+month_filters = [f for f in filters if f['field'] == 'month']
+assert month_filters, "Missing month filter"
+expected_month_value = ['2024-07-01', '2024-08-01']
+assert any(f.get('value') == expected_month_value for f in month_filters), "Missing correct month filter"
 area_filters = [f for f in filters if f['field'] == 'area']
 assert len(area_filters) == 1, f"Expected 1 area filter, got {len(area_filters)}"
 assert area_filters[0]['value'] == 'Hollywood', f"Expected 'Hollywood', got '{area_filters[0]['value']}'"

--- a/nl-poc/tests/test_mom_single_month.py
+++ b/nl-poc/tests/test_mom_single_month.py
@@ -10,7 +10,7 @@ if "yaml" not in sys.modules:
 
 if "duckdb" not in sys.modules:
     duckdb_stub = ModuleType("duckdb")
-    duckdb_stub.connect = lambda path: None
+    duckdb_stub.connect = lambda path, **kwargs: None
     duckdb_stub.DuckDBPyConnection = object
     duckdb_stub.Error = Exception
     sys.modules["duckdb"] = duckdb_stub

--- a/nl-poc/tests/test_nql_gate.py
+++ b/nl-poc/tests/test_nql_gate.py
@@ -7,7 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 if "duckdb" not in sys.modules:
     duckdb_stub = ModuleType("duckdb")
-    duckdb_stub.connect = lambda path: None
+    duckdb_stub.connect = lambda path, **kwargs: None
     duckdb_stub.DuckDBPyConnection = object
     duckdb_stub.Error = Exception
     sys.modules["duckdb"] = duckdb_stub

--- a/nl-poc/tests/test_rowcap.py
+++ b/nl-poc/tests/test_rowcap.py
@@ -12,7 +12,7 @@ if "duckdb" not in sys.modules:
     duckdb_stub = ModuleType("duckdb")
     duckdb_stub.Error = Exception
     duckdb_stub.DuckDBPyConnection = object
-    duckdb_stub.connect = lambda path: None
+    duckdb_stub.connect = lambda path, **kwargs: None
     sys.modules["duckdb"] = duckdb_stub
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/nl-poc/tests/test_sql_builder.py
+++ b/nl-poc/tests/test_sql_builder.py
@@ -8,8 +8,8 @@ sys.modules.setdefault("yaml", yaml_stub)
 duckdb_stub = types.ModuleType("duckdb")
 sys.modules.setdefault("duckdb", duckdb_stub)
 
-from app.sql_builder import _build_filters
-from app.resolver import SemanticDimension, SemanticModel
+from app.sql_builder import _build_filters, build
+from app.resolver import SemanticDimension, SemanticMetric, SemanticModel
 
 
 def _semantic_model() -> SemanticModel:
@@ -18,8 +18,11 @@ def _semantic_model() -> SemanticModel:
         date_grain="month",
         dimensions={
             "month": SemanticDimension(name="month", column="month"),
+            "area": SemanticDimension(name="area", column="area"),
         },
-        metrics={},
+        metrics={
+            "incidents": SemanticMetric(name="incidents", agg="count", grain=["month"]),
+        },
     )
 
 
@@ -32,3 +35,53 @@ def test_month_filter_collapsed_range_uses_equality():
     where_clause = _build_filters(filters, semantic, alias="base")
 
     assert where_clause == "WHERE base.month = DATE '2024-02-01'"
+
+
+def test_sql_builder_generates_count_without_grouping():
+    semantic = _semantic_model()
+    plan = {
+        "metrics": ["incidents"],
+        "group_by": [],
+        "filters": [
+            {
+                "field": "month",
+                "op": "between",
+                "value": ["2023-03-01", "2023-04-01"],
+                "exclusive_end": True,
+            }
+        ],
+        "order_by": [],
+        "limit": 0,
+        "aggregate": "count",
+        "extras": {},
+    }
+
+    sql = build(plan, semantic)
+
+    assert "COUNT(*) AS count" in sql
+    assert "GROUP BY" not in sql
+
+
+def test_sql_builder_generates_grouped_counts():
+    semantic = _semantic_model()
+    plan = {
+        "metrics": ["incidents"],
+        "group_by": ["area"],
+        "filters": [
+            {
+                "field": "month",
+                "op": "between",
+                "value": ["2023-03-01", "2023-04-01"],
+                "exclusive_end": True,
+            }
+        ],
+        "order_by": [],
+        "limit": 0,
+        "aggregate": "count",
+        "extras": {},
+    }
+
+    sql = build(plan, semantic)
+
+    assert "COUNT(*) AS count" in sql
+    assert "GROUP BY base.\"area\"" in sql

--- a/nl-poc/tests/test_time_filters.py
+++ b/nl-poc/tests/test_time_filters.py
@@ -14,7 +14,7 @@ if "duckdb" not in sys.modules:
     duckdb_stub = ModuleType("duckdb")
     duckdb_stub.Error = Exception
     duckdb_stub.DuckDBPyConnection = object
-    duckdb_stub.connect = lambda path: None
+    duckdb_stub.connect = lambda path, **kwargs: None
     sys.modules["duckdb"] = duckdb_stub
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/nl-poc/tests/test_time_parser_ranges.py
+++ b/nl-poc/tests/test_time_parser_ranges.py
@@ -1,0 +1,28 @@
+from datetime import date
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.time_utils import TimeRange, extract_time_range
+
+
+@pytest.mark.parametrize(
+    "text, today, expected_start, expected_end",
+    [
+        ("How many stabbings happened in March 2023?", date(2025, 10, 5), date(2023, 3, 1), date(2023, 4, 1)),
+        ("Incidents in Q1 2024", date(2025, 10, 5), date(2024, 1, 1), date(2024, 4, 1)),
+        ("Trends for 2024-06", date(2025, 10, 5), date(2024, 6, 1), date(2024, 7, 1)),
+        ("Report for 2023", date(2025, 10, 5), date(2023, 1, 1), date(2024, 1, 1)),
+    ],
+)
+def test_extract_time_range_exclusive(text, today, expected_start, expected_end):
+    result = extract_time_range(text, today=today)
+    assert isinstance(result, TimeRange)
+    assert result.start == expected_start
+    assert result.end == expected_end
+    assert result.exclusive_end is True

--- a/nl-poc/tests/test_ytd_endtoend.py
+++ b/nl-poc/tests/test_ytd_endtoend.py
@@ -29,7 +29,8 @@ print(f"    Group by: {plan.get('group_by')}")
 
 # Resolve plan
 print("\n[3] RESOLVING PLAN...")
-semantic = load_semantic_model()
+semantic_path = Path(__file__).parent.parent / "config" / "semantic.yml"
+semantic = load_semantic_model(semantic_path)
 db_path = Path(__file__).parent.parent / "data" / "games.duckdb"
 executor = DuckDBExecutor(db_path)
 resolver = PlanResolver(semantic, executor)


### PR DESCRIPTION
## Summary
- update time parsing to prioritise month-year patterns and consistently use exclusive end ranges
- add a metric canonicalizer for count intents and adjust resolver/sql builder/main to compile COUNT(*) safely
- expand unit coverage with new parser, canonicalizer, SQL builder, and integration tests

## Testing
- pytest tests/test_time_parser_ranges.py tests/test_canonicalize_metric.py tests/test_count_aggregate.py tests/test_sql_builder.py tests/test_main_count_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e2da528550832e85c48be0187493d1