### PR TITLE
Add canonicalization admin tooling and hot-reloadable resolver integration

### DIFF
--- a/docs/canonicalization.md
+++ b/docs/canonicalization.md
@@ -1,0 +1,48 @@
+# Canonicalization workbench
+
+The canonicalization workbench provides a lightweight flow for mapping free-form
+synonyms to canonical dimension values.  Admins can search for a token, review
+ranked candidates, and promote a mapping with a single click.  Resolver
+components consume the canonical map without requiring a process restart.
+
+## Fuzzy search and scoring
+
+The search endpoint builds a list of potential canonical values by querying the
+configured dimension column (distinct values, capped at 500 rows for
+performance).  Each candidate is scored using trigram-based cosine similarity
+between the query token and the candidate string.
+
+Scores fall in the `[0.0, 1.0]` range.  By default only matches whose cosine
+score is at least `0.75` are surfaced; this threshold can be tuned via the
+`FuzzyMatcher` instance that powers the store.  Results are sorted by score in
+descending order.  In the UI we display the top ranked matches alongside their
+scores and whether the candidate already has a canonical mapping.
+
+Practical guidelines:
+
+- Scores below `0.70` are treated as noise and will not be suggested.
+- Scores `≥ 0.80` typically represent strong matches and appear in the top
+  positions, making them ideal candidates for promotion.
+- Exact and near-exact matches generally produce scores very close to `1.0`.
+
+## Promotion lifecycle and versioning
+
+Promoting a synonym writes a row into the `canonical_map` table with the
+observed score, promoter metadata, and a monotonically increasing version.
+Every promotion increments the global version, allowing downstream caches to
+invalidate themselves without requiring any coordination beyond the database.
+
+The `CanonicalWatcher` polls the version at a configurable interval (default 1
+second), reloading the in-memory map whenever it observes a change.  The
+resolver shares the same canonicalizer instance and therefore sees updates
+within the next poll cycle.
+
+## LIKE bypass semantics
+
+Canonicalization is intentionally skipped when the raw value contains SQL `LIKE`
+patterns.  If a synonym includes the `%` wildcard (for example `%firearm%`) the
+canonicalizer treats it as an explicit pattern provided by the analyst.  In this
+scenario the resolver leaves the value untouched and records
+`like_bypass = true` while also setting `canonicalization_applied = false`.  The
+lineage metadata surfaces both flags so downstream consumers can understand why a
+value did or did not canonicalize.

--- a/migrations/0001_add_canonical_map.sql
+++ b/migrations/0001_add_canonical_map.sql
@@ -1,0 +1,11 @@
+-- Create canonical_map table for synonym → canonical mappings.
+CREATE TABLE IF NOT EXISTS canonical_map (
+    dim TEXT NOT NULL,
+    synonym TEXT NOT NULL,
+    canonical TEXT NOT NULL,
+    score DOUBLE,
+    promoted_by TEXT,
+    promoted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    version BIGINT NOT NULL
+);
+

--- a/nl-poc/app/admin/canonical.py
+++ b/nl-poc/app/admin/canonical.py
@@ -1,0 +1,196 @@
+"""Minimal admin UI for managing canonical mappings."""
+from __future__ import annotations
+
+import html
+from typing import Iterable, Optional
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from ..canonical.store import CanonicalCandidate, CanonicalStore
+from ..resolver.canonicalizer import Canonicalizer
+
+router = APIRouter()
+
+
+@router.get("/admin/canonical", response_class=HTMLResponse)
+async def canonical_admin(
+    request: Request,
+    dim: str = "area",
+    q: str = "",
+    success: Optional[str] = None,
+) -> HTMLResponse:
+    store = _get_store(request)
+    canonicalizer = _get_canonicalizer(request)
+    results: Iterable[CanonicalCandidate] = []
+    if q:
+        results = store.search(dim, q)
+    current = store.current_mapping(dim, q) if q else None
+    like_bypass = "%" in q if q else False
+    dimensions = sorted(store.dimensions())
+    html_body = _render_page(
+        dim=dim,
+        query=q,
+        results=results,
+        current=current,
+        like_bypass=like_bypass,
+        success=bool(success),
+        canonicalizer_version=canonicalizer.version if canonicalizer else None,
+        dimensions=dimensions,
+    )
+    return HTMLResponse(content=html_body)
+
+
+@router.post("/admin/canonical/promote")
+async def canonical_promote(
+    request: Request,
+    dim: str = Form(...),
+    synonym: str = Form(...),
+    canonical: str = Form(...),
+    score: float = Form(...),
+    promoted_by: Optional[str] = Form(None),
+    q: str = Form(""),
+) -> RedirectResponse:
+    store = _get_store(request)
+    canonicalizer = _get_canonicalizer(request)
+    version = store.promote(dim, synonym, canonical, score, promoted_by=promoted_by)
+    if canonicalizer:
+        canonicalizer.load(store.load_mappings(), version)
+    target = f"/admin/canonical?dim={dim}&q={synonym or q}&success=1"
+    return RedirectResponse(url=target, status_code=303)
+
+
+def _render_page(
+    *,
+    dim: str,
+    query: str,
+    results: Iterable[CanonicalCandidate],
+    current: Optional[str],
+    like_bypass: bool,
+    success: bool,
+    canonicalizer_version: Optional[int],
+    dimensions: Iterable[str],
+) -> str:
+    rows = "\n".join(_render_row(dim, query, candidate) for candidate in results)
+    if not rows:
+        rows = "<tr><td colspan=4 class='empty'>No candidates yet. Try refining your search.</td></tr>"
+    banner = ""
+    if like_bypass:
+        banner = "<div class='banner'>LIKE bypass is active for this search.</div>"
+    toast = ""
+    if success:
+        toast = "<div class='toast'>Synonym promoted successfully.</div>"
+    current_mapping = (
+        f"<p class='current'>Current mapping for <strong>{html.escape(query)}</strong>:"
+        f" <span>{html.escape(current)}</span></p>"
+        if current
+        else ""
+    )
+    version_label = (
+        f"<span class='version'>Cache version: {canonicalizer_version}</span>"
+        if canonicalizer_version is not None
+        else ""
+    )
+    return f"""
+    <!doctype html>
+    <html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Canonicalization Workbench</title>
+        <style>
+            body {{ font-family: Arial, sans-serif; margin: 2rem; background: #f5f7fb; }}
+            h1 {{ margin-bottom: 0.5rem; }}
+            form.search {{ margin-bottom: 1.5rem; display: flex; gap: 0.5rem; align-items: center; }}
+            input[type=text] {{ padding: 0.5rem; flex: 1; border: 1px solid #cbd5e1; border-radius: 4px; }}
+            select {{ padding: 0.5rem; border: 1px solid #cbd5e1; border-radius: 4px; }}
+            button {{ background: #2563eb; color: white; border: none; padding: 0.5rem 1rem; border-radius: 4px; cursor: pointer; }}
+            button:hover {{ background: #1d4ed8; }}
+            table {{ width: 100%; border-collapse: collapse; background: white; box-shadow: 0 1px 2px rgba(15,23,42,0.1); }}
+            th, td {{ padding: 0.75rem; text-align: left; border-bottom: 1px solid #e2e8f0; }}
+            th {{ background: #f1f5f9; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; color: #475569; }}
+            td.actions form {{ display: inline; }}
+            td.actions button {{ background: #16a34a; }}
+            td.actions button:hover {{ background: #15803d; }}
+            .banner {{ background: #f59e0b; color: #111827; padding: 0.5rem 0.75rem; border-radius: 4px; margin-bottom: 1rem; }}
+            .toast {{ background: #22c55e; color: white; padding: 0.5rem 0.75rem; border-radius: 4px; margin-bottom: 1rem; }}
+            .current {{ margin-bottom: 1rem; color: #334155; }}
+            .current span {{ font-weight: bold; }}
+            .empty {{ text-align: center; color: #64748b; font-style: italic; }}
+            footer {{ margin-top: 1.5rem; color: #64748b; font-size: 0.85rem; display: flex; justify-content: space-between; align-items: center; }}
+            .version {{ background: #e0f2fe; color: #0369a1; padding: 0.25rem 0.5rem; border-radius: 999px; }}
+        </style>
+    </head>
+    <body>
+        <h1>Canonicalization Workbench</h1>
+        {banner}
+        {toast}
+        <form class="search" method="get" action="/admin/canonical">
+            <label for="dim">Dimension</label>
+            <select name="dim" id="dim">
+                {''.join(_render_option(dim, option) for option in dimensions)}
+            </select>
+            <input type="text" name="q" value="{html.escape(query)}" placeholder="Search for a synonym" />
+            <button type="submit">Search</button>
+        </form>
+        {current_mapping}
+        <table>
+            <thead>
+                <tr>
+                    <th>Candidate</th>
+                    <th>Score</th>
+                    <th>Current Canonical</th>
+                    <th class="actions">Action</th>
+                </tr>
+            </thead>
+            <tbody>
+                {rows}
+            </tbody>
+        </table>
+        <footer>
+            <span>LIKE searches are bypassed when patterns are used.</span>
+            {version_label}
+        </footer>
+    </body>
+    </html>
+    """
+
+
+def _render_row(dim: str, query: str, candidate: CanonicalCandidate) -> str:
+    score = f"{candidate.score:.2f}"
+    canonical = candidate.canonical or "—"
+    return (
+        "<tr>"
+        f"<td>{html.escape(candidate.candidate)}</td>"
+        f"<td>{score}</td>"
+        f"<td>{html.escape(canonical)}</td>"
+        "<td class='actions'>"
+        "<form method='post' action='/admin/canonical/promote'>"
+        f"<input type='hidden' name='dim' value='{html.escape(dim)}' />"
+        f"<input type='hidden' name='synonym' value='{html.escape(query)}' />"
+        f"<input type='hidden' name='canonical' value='{html.escape(candidate.candidate)}' />"
+        f"<input type='hidden' name='score' value='{candidate.score}' />"
+        f"<input type='hidden' name='q' value='{html.escape(query)}' />"
+        "<button type='submit'>Promote</button>"
+        "</form>"
+        "</td>"
+        "</tr>"
+    )
+
+
+def _render_option(current: str, option: str) -> str:
+    selected = " selected" if current == option else ""
+    return f"<option value='{html.escape(option)}'{selected}>{html.escape(option.title())}</option>"
+
+
+def _get_store(request: Request) -> CanonicalStore:
+    store = getattr(request.app.state, "canonical_store", None)
+    if not isinstance(store, CanonicalStore):
+        raise HTTPException(status_code=503, detail="Canonical store not ready")
+    return store
+
+
+def _get_canonicalizer(request: Request) -> Optional[Canonicalizer]:
+    canonicalizer = getattr(request.app.state, "canonicalizer", None)
+    if canonicalizer is not None and not isinstance(canonicalizer, Canonicalizer):
+        raise HTTPException(status_code=503, detail="Canonicalizer unavailable")
+    return canonicalizer

--- a/nl-poc/app/canonical/__init__.py
+++ b/nl-poc/app/canonical/__init__.py
@@ -1,0 +1,7 @@
+"""Canonical value management utilities."""
+
+from .store import CanonicalStore
+from .fuzzy import FuzzyMatcher
+from .watcher import CanonicalWatcher
+
+__all__ = ["CanonicalStore", "FuzzyMatcher", "CanonicalWatcher"]

--- a/nl-poc/app/canonical/fuzzy.py
+++ b/nl-poc/app/canonical/fuzzy.py
@@ -1,0 +1,79 @@
+"""Lightweight fuzzy string matching utilities."""
+from __future__ import annotations
+
+from collections import Counter
+import re
+from dataclasses import dataclass
+from math import sqrt
+from typing import Iterable, List, Sequence, Tuple
+
+
+def _normalise(text: str) -> str:
+    return text.strip().lower()
+
+
+def _trigrams(text: str) -> Counter[str]:
+    if not text:
+        return Counter()
+    padded = f"  {_normalise(text)}  "
+    return Counter(padded[i : i + 3] for i in range(len(padded) - 2))
+
+
+def cosine_similarity(a: str, b: str) -> float:
+    """Return cosine similarity between two strings using trigram vectors."""
+
+    vec_a = _trigrams(a)
+    vec_b = _trigrams(b)
+    if not vec_a or not vec_b:
+        return 0.0
+    dot = 0.0
+    for token, weight in vec_a.items():
+        dot += float(weight * vec_b.get(token, 0))
+    norm_a = sqrt(sum(float(weight * weight) for weight in vec_a.values()))
+    norm_b = sqrt(sum(float(weight * weight) for weight in vec_b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+@dataclass
+class FuzzyMatch:
+    candidate: str
+    score: float
+
+
+@dataclass
+class FuzzyMatcher:
+    """Search helper that ranks candidates using trigram cosine similarity."""
+
+    threshold: float = 0.75
+    limit: int = 10
+
+    def rank(self, query: str, candidates: Sequence[str]) -> List[FuzzyMatch]:
+        scored: List[Tuple[float, str]] = []
+        query_norm = _normalise(query)
+        for candidate in candidates:
+            score = cosine_similarity(query, candidate)
+            candidate_norm = _normalise(candidate)
+            if candidate_norm.startswith(query_norm):
+                score = max(score, 0.9)
+            elif query_norm and len(query_norm) >= 3 and query_norm in candidate_norm:
+                fraction = min(len(query_norm) / max(len(candidate_norm), 1), 1.0)
+                score = max(score, 0.75 + 0.2 * fraction)
+            acronym = _acronym(candidate)
+            if acronym and _normalise(acronym).startswith(query_norm):
+                fraction = min(len(query_norm) / len(acronym), 1.0)
+                score = max(score, 0.85 + 0.15 * fraction)
+            if score < self.threshold:
+                continue
+            scored.append((score, candidate))
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        return [FuzzyMatch(candidate=cand, score=score) for score, cand in scored[: self.limit]]
+
+    def search(self, query: str, candidates: Iterable[str]) -> List[FuzzyMatch]:
+        return self.rank(query, list(candidates))
+
+
+def _acronym(text: str) -> str:
+    parts = re.findall(r"[A-Za-z0-9]+", text)
+    return "".join(part[0] for part in parts if part)

--- a/nl-poc/app/canonical/store.py
+++ b/nl-poc/app/canonical/store.py
@@ -1,0 +1,171 @@
+"""Persistent storage helpers for canonical mappings."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import duckdb
+
+from ..executor import DuckDBExecutor
+from ..resolver import SemanticDimension, SemanticModel
+from .fuzzy import FuzzyMatcher, FuzzyMatch
+
+
+@dataclass
+class CanonicalCandidate:
+    candidate: str
+    score: float
+    canonical: Optional[str]
+
+
+class CanonicalStore:
+    """Manage canonical mappings stored in DuckDB."""
+
+    def __init__(
+        self,
+        executor: DuckDBExecutor,
+        semantic: SemanticModel,
+        *,
+        matcher: Optional[FuzzyMatcher] = None,
+        max_candidates: int = 500,
+    ) -> None:
+        self._db_path = Path(executor.db_path)
+        self._semantic = semantic
+        self._matcher = matcher or FuzzyMatcher()
+        self._max_candidates = max_candidates
+        self._ensure_table()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def search(self, dim: str, token: str) -> List[CanonicalCandidate]:
+        if not token:
+            return []
+        values = self._load_candidates(dim)
+        matches: List[FuzzyMatch] = self._matcher.rank(token, values)
+        existing = self._lookup_mapping(dim)
+        return [
+            CanonicalCandidate(candidate=m.candidate, score=m.score, canonical=existing.get(_normalise(m.candidate)))
+            for m in matches
+        ]
+
+    def promote(
+        self,
+        dim: str,
+        synonym: str,
+        canonical: str,
+        score: Optional[float],
+        *,
+        promoted_by: Optional[str] = None,
+    ) -> int:
+        next_version = self._next_version()
+        now = datetime.now(timezone.utc)
+        score_value = float(score) if score is not None else None
+        promoter = promoted_by or "admin"
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM canonical_map WHERE dim = ? AND lower(synonym) = lower(?)",
+                [dim, synonym],
+            )
+            conn.execute(
+                """
+                INSERT INTO canonical_map
+                (dim, synonym, canonical, score, promoted_by, promoted_at, version)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                [dim, synonym, canonical, score_value, promoter, now, next_version],
+            )
+        return next_version
+
+    def get_version(self) -> int:
+        with self._connect() as conn:
+            row = conn.execute("SELECT COALESCE(MAX(version), 0) FROM canonical_map").fetchone()
+        return int(row[0]) if row else 0
+
+    def dimensions(self) -> List[str]:
+        return list(self._semantic.dimensions.keys())
+
+    def current_mapping(self, dim: str, synonym: str) -> Optional[str]:
+        if not synonym:
+            return None
+        mapping = self._lookup_mapping(dim)
+        return mapping.get(_normalise(synonym))
+
+    def load_mappings(self) -> Dict[str, Dict[str, Dict[str, float]]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT dim, synonym, canonical, score FROM canonical_map ORDER BY version"
+            ).fetchall()
+        mappings: Dict[str, Dict[str, Dict[str, float]]] = {}
+        for dim, synonym, canonical, score in rows:
+            dim_map = mappings.setdefault(dim, {})
+            dim_map[_normalise(str(synonym))] = {"canonical": str(canonical), "score": float(score or 0.0)}
+        return mappings
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _connect(self) -> duckdb.DuckDBPyConnection:
+        return duckdb.connect(str(self._db_path))
+
+    def _ensure_table(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS canonical_map (
+                    dim TEXT NOT NULL,
+                    synonym TEXT NOT NULL,
+                    canonical TEXT NOT NULL,
+                    score DOUBLE,
+                    promoted_by TEXT,
+                    promoted_at TIMESTAMP,
+                    version BIGINT NOT NULL
+                )
+                """
+            )
+
+    def _load_candidates(self, dim: str) -> List[str]:
+        dimension = self._dimension(dim)
+        table = self._semantic.table
+        column_sql = self._dimension_sql(dimension)
+        sql = (
+            f"SELECT DISTINCT {column_sql} AS value "
+            f"FROM {table} "
+            f"WHERE {column_sql} IS NOT NULL "
+            f"LIMIT {self._max_candidates}"
+        )
+        with self._connect() as conn:
+            rows = conn.execute(sql).fetchall()
+        return [str(row[0]) for row in rows if row and row[0] is not None]
+
+    def _dimension(self, dim: str) -> SemanticDimension:
+        try:
+            return self._semantic.dimensions[dim]
+        except KeyError as exc:  # pragma: no cover - guard clause
+            raise ValueError(f"Unknown dimension '{dim}'") from exc
+
+    def _dimension_sql(self, dimension: SemanticDimension) -> str:
+        column = dimension.column
+        if dimension.name == "month":
+            return "DATE_TRUNC('month', \"DATE OCC\")"
+        if " " in column:
+            return f'"{column}"'
+        return f'"{column}"'
+
+    def _lookup_mapping(self, dim: str) -> Dict[str, str]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT synonym, canonical FROM canonical_map WHERE dim = ?",
+                [dim],
+            ).fetchall()
+        return { _normalise(str(synonym)): str(canonical) for synonym, canonical in rows }
+
+    def _next_version(self) -> int:
+        current = self.get_version()
+        return current + 1
+
+
+def _normalise(value: str) -> str:
+    return value.strip().lower()

--- a/nl-poc/app/canonical/watcher.py
+++ b/nl-poc/app/canonical/watcher.py
@@ -1,0 +1,56 @@
+"""Background watcher that keeps canonical caches in sync."""
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from .store import CanonicalStore
+from ..resolver.canonicalizer import Canonicalizer
+
+
+class CanonicalWatcher:
+    """Poll the canonical_map version and refresh caches on change."""
+
+    def __init__(
+        self,
+        store: CanonicalStore,
+        canonicalizer: Canonicalizer,
+        *,
+        interval: float = 2.0,
+    ) -> None:
+        self._store = store
+        self._canonicalizer = canonicalizer
+        self._interval = interval
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._initial_load()
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, name="canonical-watcher", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if not self._thread:
+            return
+        self._stop.set()
+        self._thread.join(timeout=self._interval * 2)
+        self._thread = None
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _initial_load(self) -> None:
+        version = self._store.get_version()
+        mappings = self._store.load_mappings()
+        self._canonicalizer.load(mappings, version)
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._interval):
+            version = self._store.get_version()
+            if version == self._canonicalizer.version:
+                continue
+            mappings = self._store.load_mappings()
+            self._canonicalizer.load(mappings, version)

--- a/nl-poc/app/resolver/canonicalizer.py
+++ b/nl-poc/app/resolver/canonicalizer.py
@@ -1,0 +1,66 @@
+"""Canonical value resolution helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import RLock
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class CanonicalResolution:
+    value: object
+    applied: bool
+    like_bypass: bool
+    canonical: Optional[str] = None
+    synonym: Optional[str] = None
+
+
+class Canonicalizer:
+    """Resolve raw dimension values using canonical_map entries."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._version: int = 0
+        self._mappings: Dict[str, Dict[str, Dict[str, float]]] = {}
+
+    @property
+    def version(self) -> int:
+        with self._lock:
+            return self._version
+
+    def load(self, mappings: Dict[str, Dict[str, Dict[str, float]]], version: int) -> None:
+        with self._lock:
+            self._mappings = {dim: dict(entries) for dim, entries in mappings.items()}
+            self._version = int(version)
+
+    def resolve(self, dim: str, raw: object) -> CanonicalResolution:
+        if not isinstance(raw, str):
+            return CanonicalResolution(value=raw, applied=False, like_bypass=False)
+        token = raw.strip()
+        if not token:
+            return CanonicalResolution(value=raw, applied=False, like_bypass=False)
+        like_bypass = "%" in token
+        if like_bypass:
+            return CanonicalResolution(value=raw, applied=False, like_bypass=True)
+        lookup = self._get_dim_map(dim)
+        normalised = _normalise(token)
+        entry = lookup.get(normalised)
+        if not entry:
+            return CanonicalResolution(value=raw, applied=False, like_bypass=False)
+        canonical = entry.get("canonical") or raw
+        return CanonicalResolution(
+            value=canonical,
+            applied=True,
+            like_bypass=False,
+            canonical=canonical,
+            synonym=token,
+        )
+
+    # ------------------------------------------------------------------
+    def _get_dim_map(self, dim: str) -> Dict[str, Dict[str, float]]:
+        with self._lock:
+            return dict(self._mappings.get(dim, {}))
+
+
+def _normalise(value: str) -> str:
+    return value.strip().lower()

--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -1,0 +1,140 @@
+import json
+import sys
+import types
+from pathlib import Path
+import duckdb
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+NL_POC = ROOT / "nl-poc"
+if str(NL_POC) not in sys.path:
+    sys.path.insert(0, str(NL_POC))
+
+if "yaml" not in sys.modules:
+    yaml_stub = types.ModuleType("yaml")
+
+    def _safe_load(stream):
+        if hasattr(stream, "read"):
+            text = stream.read()
+        else:
+            text = stream
+        text = (text or "").strip()
+        if not text:
+            return {}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return {}
+
+    yaml_stub.safe_load = _safe_load  # type: ignore[attr-defined]
+    sys.modules["yaml"] = yaml_stub
+
+from app.canonical.store import CanonicalStore
+from app.executor import DuckDBExecutor
+from app.resolver import SemanticDimension, SemanticMetric, SemanticModel
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "canonical.duckdb"
+    con = duckdb.connect(str(path))
+    con.execute(
+        """
+        CREATE TABLE games (
+            Title TEXT,
+            Platform TEXT
+        )
+        """
+    )
+    con.execute(
+        "INSERT INTO games VALUES (?, ?), (?, ?), (?, ?), (?, ?)",
+        [
+            "Mortal Kombat 1",
+            "Arcade",
+            "Mortal Kombat II",
+            "Arcade",
+            "Street Fighter",
+            "Arcade",
+            "Mario Kart",
+            "Console",
+        ],
+    )
+    con.execute(
+        """
+        CREATE TABLE "la_crime_raw" (
+            "AREA NAME" TEXT,
+            "Crm Cd Desc" TEXT,
+            "Premis Desc" TEXT,
+            "Weapon Desc" TEXT,
+            "Vict Age" INTEGER,
+            "DATE OCC" DATE
+        )
+        """
+    )
+    con.execute(
+        "INSERT INTO la_crime_raw VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)",
+        [
+            "Central",
+            "Robbery",
+            "Street",
+            "Firearm",
+            32,
+            "2024-01-01",
+            "Downtown",
+            "Robbery",
+            "Street",
+            "Unknown",
+            28,
+            "2024-01-02",
+            "Harbor",
+            "Assault",
+            "Store",
+            "Knife",
+            41,
+            "2024-02-10",
+            "Mission",
+            "Burglary",
+            "House",
+            "None",
+            38,
+            "2024-03-12",
+        ],
+    )
+    con.close()
+    return path
+
+
+@pytest.fixture()
+def executor(db_path: Path) -> DuckDBExecutor:
+    return DuckDBExecutor(db_path)
+
+
+@pytest.fixture()
+def games_semantic() -> SemanticModel:
+    dimensions = {
+        "title": SemanticDimension(name="title", column="Title"),
+    }
+    metrics = {
+        "count": SemanticMetric(name="count", agg="count", grain=["title"]),
+    }
+    return SemanticModel(table="games", date_grain="month", dimensions=dimensions, metrics=metrics)
+
+
+@pytest.fixture()
+def crime_semantic() -> SemanticModel:
+    dimensions = {
+        "area": SemanticDimension(name="area", column="AREA NAME"),
+        "weapon": SemanticDimension(name="weapon", column="Weapon Desc"),
+    }
+    metrics = {
+        "count": SemanticMetric(name="count", agg="count", grain=["area"]),
+    }
+    return SemanticModel(table="la_crime_raw", date_grain="month", dimensions=dimensions, metrics=metrics)
+
+
+@pytest.fixture()
+def make_store(executor: DuckDBExecutor):
+    def _make(semantic: SemanticModel) -> CanonicalStore:
+        return CanonicalStore(executor, semantic)
+
+    return _make

--- a/tests/canonical/test_resolve_like_bypass.py
+++ b/tests/canonical/test_resolve_like_bypass.py
@@ -1,0 +1,22 @@
+from app.canonical.store import CanonicalStore
+from app.resolver import PlanResolver
+from app.resolver.canonicalizer import Canonicalizer
+
+
+def test_like_bypass_flag(make_store, crime_semantic, executor):
+    store: CanonicalStore = make_store(crime_semantic)
+    canonicalizer = Canonicalizer()
+    canonicalizer.load(store.load_mappings(), store.get_version())
+    resolver = PlanResolver(crime_semantic, executor, canonicalizer=canonicalizer)
+
+    plan = {
+        "metrics": ["count"],
+        "filters": [
+            {"field": "weapon", "op": "like", "value": "%firearm%"},
+        ],
+    }
+    resolved = resolver.resolve(plan)
+    assert resolved["filters"][0]["value"] == "%firearm%"
+    meta = resolved.get("canonicalization")
+    assert meta["like_bypass"] is True
+    assert meta["applied"] is False

--- a/tests/canonical/test_search_promote.py
+++ b/tests/canonical/test_search_promote.py
@@ -1,0 +1,56 @@
+import time
+
+from app.canonical.store import CanonicalStore
+from app.canonical.watcher import CanonicalWatcher
+from app.resolver import PlanResolver
+from app.resolver.canonicalizer import Canonicalizer
+
+
+def test_search_and_promote(make_store, games_semantic, executor):
+    store: CanonicalStore = make_store(games_semantic)
+    canonicalizer = Canonicalizer()
+    canonicalizer.load(store.load_mappings(), store.get_version())
+    resolver = PlanResolver(games_semantic, executor, canonicalizer=canonicalizer)
+
+    results = store.search("title", "mk")
+    assert results, "Expected fuzzy search to return at least one candidate"
+    target = next(candidate for candidate in results if "mortal kombat" in candidate.candidate.lower())
+
+    before_version = store.get_version()
+    new_version = store.promote("title", "MK1", target.candidate, target.score, promoted_by="pytest")
+    assert new_version == before_version + 1
+
+    canonicalizer.load(store.load_mappings(), new_version)
+    resolution = canonicalizer.resolve("title", "mk1")
+    assert resolution.applied
+    assert resolution.value == target.candidate
+
+    plan = {"metrics": ["count"], "filters": [{"field": "title", "op": "=", "value": "MK1"}]}
+    resolved = resolver.resolve(plan)
+    assert resolved["filters"][0]["value"] == target.candidate
+    assert resolved["canonicalization"]["applied"] is True
+
+
+def test_hot_reload_watcher(make_store, crime_semantic, executor):
+    store: CanonicalStore = make_store(crime_semantic)
+    canonicalizer = Canonicalizer()
+    watcher = CanonicalWatcher(store, canonicalizer, interval=0.1)
+    watcher.start()
+    try:
+        resolver = PlanResolver(crime_semantic, executor, canonicalizer=canonicalizer)
+        canonicalizer.load(store.load_mappings(), store.get_version())
+        plan = {"metrics": ["count"], "filters": [{"field": "area", "op": "=", "value": "Downtown"}]}
+        resolved = resolver.resolve(plan)
+        assert resolved["filters"][0]["value"] == "Downtown"
+        assert resolved["canonicalization"]["applied"] is False
+
+        version = store.promote("area", "Downtown", "Central", 0.92)
+        for _ in range(30):
+            if canonicalizer.version >= version:
+                break
+            time.sleep(0.1)
+        refreshed = resolver.resolve(plan)
+        assert refreshed["filters"][0]["value"] == "Central"
+        assert refreshed["canonicalization"]["applied"] is True
+    finally:
+        watcher.stop()

--- a/tests/canonical/test_thresholds.py
+++ b/tests/canonical/test_thresholds.py
@@ -1,0 +1,10 @@
+from app.canonical.store import CanonicalStore
+
+
+def test_threshold_filtering(make_store, crime_semantic):
+    store: CanonicalStore = make_store(crime_semantic)
+    results = store.search("area", "cent")
+    assert results, "Expected Central to appear in fuzzy results"
+    top_three = results[:3]
+    assert any(candidate.candidate == "Central" and candidate.score >= 0.8 for candidate in top_three)
+    assert all(candidate.score >= 0.7 for candidate in results)


### PR DESCRIPTION
## Summary
- add a canonical_map migration plus canonical store, fuzzy matcher, and watcher modules for synonym management
- wire a canonicalizer into the resolver and FastAPI app, expose lineage flags, and serve an admin UI for promotions
- document canonicalization behavior and cover the flow with focused pytest scenarios

## Testing
- pytest tests/canonical -q

------
https://chatgpt.com/codex/tasks/task_e_68e2efb7fff8832e940028e9397e0b68