### PR TITLE
Add canonical admin dashboard APIs

### DIFF
--- a/docs/canonicalization.md
+++ b/docs/canonicalization.md
@@ -1,48 +1,54 @@
 # Canonicalization workbench
 
-The canonicalization workbench provides a lightweight flow for mapping free-form
-synonyms to canonical dimension values.  Admins can search for a token, review
-ranked candidates, and promote a mapping with a single click.  Resolver
-components consume the canonical map without requiring a process restart.
+The workbench is an admin-only surface for curating synonym → canonical value
+mappings.  It lives at `/admin/canonical` and consists of an HTML workbench plus
+a matching JSON API exposed under `/api/admin/canonical`.  The HTML form lets an
+operator search for a token, review fuzzy matched candidates, and promote a
+mapping with one click.  The JSON API powers automation and integration tests.
+
+## Storage schema
+
+Canonical mappings are stored in two tables:
+
+- `canonical_map`: `dim`, `synonym`, `canonical`, `score`, and audit metadata.
+- `canonical_meta`: a single `version` row incremented on every promotion.
+
+Only `SELECT`, `INSERT`, and `UPDATE` statements are used to respect the
+no-destructive-migrations constraint.
 
 ## Fuzzy search and scoring
 
-The search endpoint builds a list of potential canonical values by querying the
-configured dimension column (distinct values, capped at 500 rows for
-performance).  Each candidate is scored using trigram-based cosine similarity
-between the query token and the candidate string.
+Search builds a candidate set from two sources: distinct values for the selected
+dimension in `la_crime_raw` and any existing synonyms already promoted for that
+dimension.  The `FuzzyMatcher` ranks candidates using trigram-based cosine
+similarity.  Results contain:
 
-Scores fall in the `[0.0, 1.0]` range.  By default only matches whose cosine
-score is at least `0.75` are surfaced; this threshold can be tuned via the
-`FuzzyMatcher` instance that powers the store.  Results are sorted by score in
-descending order.  In the UI we display the top ranked matches alongside their
-scores and whether the candidate already has a canonical mapping.
+- `candidate`: the value we can promote to.
+- `score`: similarity score between the query and candidate (`0.0`–`1.0`).
+- `canonical`: the canonical value currently mapped to the candidate (if any).
 
-Practical guidelines:
+Scores ≥ ~0.80 are generally strong matches; exact or prefix matches typically
+hover near `1.0`.
 
-- Scores below `0.70` are treated as noise and will not be suggested.
-- Scores `≥ 0.80` typically represent strong matches and appear in the top
-  positions, making them ideal candidates for promotion.
-- Exact and near-exact matches generally produce scores very close to `1.0`.
+## Promotion + live cache reload
 
-## Promotion lifecycle and versioning
+Both the HTML form and JSON API post to `/admin/canonical/promote`.  Promotions
+either insert or update the `canonical_map` entry and bump the global version in
+`canonical_meta`.  The FastAPI app immediately reloads the in-memory
+`Canonicalizer` so callers observe the new mapping without restarting the
+service.  A background `CanonicalWatcher` keeps long-lived processes in sync by
+polling the version every second.
 
-Promoting a synonym writes a row into the `canonical_map` table with the
-observed score, promoter metadata, and a monotonically increasing version.
-Every promotion increments the global version, allowing downstream caches to
-invalidate themselves without requiring any coordination beyond the database.
+## Optional basic authentication
 
-The `CanonicalWatcher` polls the version at a configurable interval (default 1
-second), reloading the in-memory map whenever it observes a change.  The
-resolver shares the same canonicalizer instance and therefore sees updates
-within the next poll cycle.
+Enable `ADMIN_BASIC_AUTH=true` to require HTTP Basic Auth for both the HTML and
+JSON routes.  Override `ADMIN_USER` / `ADMIN_PASS` to change credentials.  When
+disabled (the default), the workbench remains unsecured for local development.
 
-## LIKE bypass semantics
+## Resolver behaviour
 
-Canonicalization is intentionally skipped when the raw value contains SQL `LIKE`
-patterns.  If a synonym includes the `%` wildcard (for example `%firearm%`) the
-canonicalizer treats it as an explicit pattern provided by the analyst.  In this
-scenario the resolver leaves the value untouched and records
-`like_bypass = true` while also setting `canonicalization_applied = false`.  The
-lineage metadata surfaces both flags so downstream consumers can understand why a
-value did or did not canonicalize.
+The resolver normalises synonyms to lowercase before lookup and only applies a
+canonical value when an exact synonym match is found.  Tokens containing SQL
+`LIKE` wildcards (e.g. `%firearm%`) bypass canonicalization to preserve analyst
+intent.  Callers can inspect the `CanonicalResolution` object to see whether a
+mapping was applied and which canonical value was chosen.

--- a/migrations/0001_add_canonical_map.sql
+++ b/migrations/0001_add_canonical_map.sql
@@ -1,11 +1,26 @@
--- Create canonical_map table for synonym → canonical mappings.
+-- Canonical synonym → canonical mapping storage.
+CREATE SEQUENCE IF NOT EXISTS canonical_map_id_seq START 1;
+
 CREATE TABLE IF NOT EXISTS canonical_map (
+    id BIGINT DEFAULT nextval('canonical_map_id_seq'),
     dim TEXT NOT NULL,
     synonym TEXT NOT NULL,
     canonical TEXT NOT NULL,
-    score DOUBLE,
+    score DOUBLE NOT NULL DEFAULT 1.0,
     promoted_by TEXT,
-    promoted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    version BIGINT NOT NULL
+    promoted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_canonical_map_dim_syn
+    ON canonical_map(dim, synonym);
+
+CREATE TABLE IF NOT EXISTS canonical_meta (
+    k TEXT PRIMARY KEY,
+    v BIGINT NOT NULL
+);
+
+INSERT INTO canonical_meta(k, v)
+    VALUES ('version', 1)
+    ON CONFLICT (k) DO NOTHING;
 

--- a/nl-poc/app/canonical/store.py
+++ b/nl-poc/app/canonical/store.py
@@ -15,6 +15,8 @@ from .fuzzy import FuzzyMatcher, FuzzyMatch
 
 @dataclass
 class CanonicalCandidate:
+    """Result row returned from a canonical search."""
+
     candidate: str
     score: float
     canonical: Optional[str]
@@ -35,7 +37,7 @@ class CanonicalStore:
         self._semantic = semantic
         self._matcher = matcher or FuzzyMatcher()
         self._max_candidates = max_candidates
-        self._ensure_table()
+        self._ensure_tables()
 
     # ------------------------------------------------------------------
     # Public API
@@ -47,7 +49,11 @@ class CanonicalStore:
         matches: List[FuzzyMatch] = self._matcher.rank(token, values)
         existing = self._lookup_mapping(dim)
         return [
-            CanonicalCandidate(candidate=m.candidate, score=m.score, canonical=existing.get(_normalise(m.candidate)))
+            CanonicalCandidate(
+                candidate=m.candidate,
+                score=m.score,
+                canonical=existing.get(_normalise(m.candidate)),
+            )
             for m in matches
         ]
 
@@ -60,29 +66,44 @@ class CanonicalStore:
         *,
         promoted_by: Optional[str] = None,
     ) -> int:
-        next_version = self._next_version()
         now = datetime.now(timezone.utc)
-        score_value = float(score) if score is not None else None
         promoter = promoted_by or "admin"
+        score_value = float(score) if score is not None else 1.0
         with self._connect() as conn:
-            conn.execute(
-                "DELETE FROM canonical_map WHERE dim = ? AND lower(synonym) = lower(?)",
+            existing = conn.execute(
+                "SELECT id FROM canonical_map WHERE dim = ? AND lower(synonym) = lower(?)",
                 [dim, synonym],
-            )
-            conn.execute(
-                """
-                INSERT INTO canonical_map
-                (dim, synonym, canonical, score, promoted_by, promoted_at, version)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                [dim, synonym, canonical, score_value, promoter, now, next_version],
-            )
-        return next_version
+            ).fetchone()
+            if existing:
+                conn.execute(
+                    """
+                    UPDATE canonical_map
+                    SET synonym = ?,
+                        canonical = ?,
+                        score = ?,
+                        promoted_by = ?,
+                        promoted_at = ?
+                    WHERE id = ?
+                    """,
+                    [synonym, canonical, score_value, promoter, now, int(existing[0])],
+                )
+            else:
+                conn.execute(
+                    """
+                    INSERT INTO canonical_map (dim, synonym, canonical, score, promoted_by, promoted_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    [dim, synonym, canonical, score_value, promoter, now],
+                )
+            version = self._bump_version(conn)
+        return version
 
     def get_version(self) -> int:
         with self._connect() as conn:
-            row = conn.execute("SELECT COALESCE(MAX(version), 0) FROM canonical_map").fetchone()
-        return int(row[0]) if row else 0
+            row = conn.execute(
+                "SELECT v FROM canonical_meta WHERE k = 'version'"
+            ).fetchone()
+        return int(row[0]) if row else 1
 
     def dimensions(self) -> List[str]:
         return list(self._semantic.dimensions.keys())
@@ -96,12 +117,15 @@ class CanonicalStore:
     def load_mappings(self) -> Dict[str, Dict[str, Dict[str, float]]]:
         with self._connect() as conn:
             rows = conn.execute(
-                "SELECT dim, synonym, canonical, score FROM canonical_map ORDER BY version"
+                "SELECT dim, synonym, canonical, score FROM canonical_map"
             ).fetchall()
         mappings: Dict[str, Dict[str, Dict[str, float]]] = {}
         for dim, synonym, canonical, score in rows:
             dim_map = mappings.setdefault(dim, {})
-            dim_map[_normalise(str(synonym))] = {"canonical": str(canonical), "score": float(score or 0.0)}
+            dim_map[_normalise(str(synonym))] = {
+                "canonical": str(canonical),
+                "score": float(score or 0.0),
+            }
         return mappings
 
     # ------------------------------------------------------------------
@@ -110,20 +134,36 @@ class CanonicalStore:
     def _connect(self) -> duckdb.DuckDBPyConnection:
         return duckdb.connect(str(self._db_path))
 
-    def _ensure_table(self) -> None:
+    def _ensure_tables(self) -> None:
         with self._connect() as conn:
+            conn.execute("CREATE SEQUENCE IF NOT EXISTS canonical_map_id_seq START 1")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS canonical_map (
+                    id BIGINT DEFAULT nextval('canonical_map_id_seq'),
                     dim TEXT NOT NULL,
                     synonym TEXT NOT NULL,
                     canonical TEXT NOT NULL,
-                    score DOUBLE,
+                    score DOUBLE DEFAULT 1.0,
                     promoted_by TEXT,
-                    promoted_at TIMESTAMP,
-                    version BIGINT NOT NULL
+                    promoted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (id)
                 )
                 """
+            )
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS canonical_map_dim_syn ON canonical_map(dim, synonym)"
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS canonical_meta (
+                    k TEXT PRIMARY KEY,
+                    v BIGINT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO canonical_meta(k, v) VALUES ('version', 1) ON CONFLICT (k) DO NOTHING"
             )
 
     def _load_candidates(self, dim: str) -> List[str]:
@@ -136,9 +176,30 @@ class CanonicalStore:
             f"WHERE {column_sql} IS NOT NULL "
             f"LIMIT {self._max_candidates}"
         )
+        values: List[str] = []
         with self._connect() as conn:
             rows = conn.execute(sql).fetchall()
-        return [str(row[0]) for row in rows if row and row[0] is not None]
+            values.extend(str(row[0]) for row in rows if row and row[0] is not None)
+            synonym_rows = conn.execute(
+                "SELECT synonym FROM canonical_map WHERE dim = ?",
+                [dim],
+            ).fetchall()
+            canonical_rows = conn.execute(
+                "SELECT canonical FROM canonical_map WHERE dim = ?",
+                [dim],
+            ).fetchall()
+        values.extend(str(row[0]) for row in synonym_rows if row and row[0])
+        values.extend(str(row[0]) for row in canonical_rows if row and row[0])
+        # deduplicate while preserving order
+        seen = set()
+        deduped: List[str] = []
+        for value in values:
+            key = value.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(value)
+        return deduped
 
     def _dimension(self, dim: str) -> SemanticDimension:
         try:
@@ -160,11 +221,21 @@ class CanonicalStore:
                 "SELECT synonym, canonical FROM canonical_map WHERE dim = ?",
                 [dim],
             ).fetchall()
-        return { _normalise(str(synonym)): str(canonical) for synonym, canonical in rows }
+        return {_normalise(str(synonym)): str(canonical) for synonym, canonical in rows}
 
-    def _next_version(self) -> int:
-        current = self.get_version()
-        return current + 1
+    def _bump_version(self, conn: duckdb.DuckDBPyConnection) -> int:
+        current = conn.execute(
+            "SELECT v FROM canonical_meta WHERE k = 'version'"
+        ).fetchone()
+        if current:
+            next_value = int(current[0]) + 1
+            conn.execute(
+                "UPDATE canonical_meta SET v = ? WHERE k = 'version'",
+                [next_value],
+            )
+            return next_value
+        conn.execute("INSERT INTO canonical_meta(k, v) VALUES ('version', 1)")
+        return 1
 
 
 def _normalise(value: str) -> str:

--- a/nl-poc/app/main.py
+++ b/nl-poc/app/main.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from . import guardrails, sql_builder, viz
+from .admin.canonical import api_router as canonical_api_router
 from .admin.canonical import router as canonical_admin_router
 from .canonical import CanonicalStore, CanonicalWatcher
 from .http.feedback import router as feedback_router
@@ -92,6 +93,7 @@ app.add_middleware(
 if hasattr(app, "include_router"):
     app.include_router(feedback_router)
     app.include_router(canonical_admin_router)
+    app.include_router(canonical_api_router)
 
 _state: Dict[str, Any] = {
     "last_debug": None,

--- a/nl-poc/tests/canonical/test_admin_canonical.py
+++ b/nl-poc/tests/canonical/test_admin_canonical.py
@@ -1,0 +1,88 @@
+import csv
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import app
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+CSV_PATH = DATA_DIR / "canonical_fixture.csv"
+DB_PATH = DATA_DIR / "games.duckdb"
+
+
+@pytest.fixture()
+def client() -> Iterator[TestClient]:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+    with CSV_PATH.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow([
+            "DATE OCC",
+            "AREA NAME",
+            "Crm Cd Desc",
+            "Premis Desc",
+            "Weapon Desc",
+            "DR_NO",
+            "Vict Age",
+        ])
+        writer.writerow([
+            "2024-01-01",
+            "Downtown",
+            "Robbery",
+            "Street",
+            "None",
+            "1",
+            "34",
+        ])
+        writer.writerow([
+            "2024-01-02",
+            "Hollywood",
+            "Burglary",
+            "Shop",
+            "Knife",
+            "2",
+            "29",
+        ])
+    with TestClient(app) as test_client:
+        yield test_client
+    if CSV_PATH.exists():
+        CSV_PATH.unlink()
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+
+
+def test_json_search_smoke(client: TestClient) -> None:
+    response = client.get("/api/admin/canonical", params={"dim": "area", "q": "holly"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert payload, "expected at least one candidate"
+    assert any(item["candidate"] == "Hollywood" for item in payload)
+
+
+def test_promote_roundtrip(client: TestClient) -> None:
+    promote_payload = {
+        "dim": "area",
+        "synonym": "hollywd",
+        "canonical": "Hollywood",
+        "score": 0.9,
+    }
+    response = client.post("/api/admin/canonical/promote", json=promote_payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    resolution = app.state.canonicalizer.resolve("area", "hollywd")
+    assert resolution.applied is True
+    assert resolution.value == "Hollywood"
+    search = client.get("/api/admin/canonical", params={"dim": "area", "q": "hollywd"})
+    assert search.status_code == 200
+    candidates = search.json()
+    assert any(item["canonical"] == "Hollywood" for item in candidates)


### PR DESCRIPTION
## Summary
- add HTML + JSON admin endpoints with optional basic auth and live cache reloads
- extend the canonical store schema/version tracking and update documentation
- add integration-style tests covering the canonical admin API

## Testing
- pytest tests/canonical/test_admin_canonical.py

------
https://chatgpt.com/codex/tasks/task_e_68e2f59921cc832e8d25947949649c41