### PR TITLE
Add AgentKit layer and tools for analytics agent

### DIFF
--- a/nl-poc/app/agentkit/__init__.py
+++ b/nl-poc/app/agentkit/__init__.py
@@ -1,0 +1,6 @@
+"""AgentKit integration package."""
+from __future__ import annotations
+
+from .routes import router
+
+__all__ = ["router"]

--- a/nl-poc/app/agentkit/routes.py
+++ b/nl-poc/app/agentkit/routes.py
@@ -1,0 +1,290 @@
+"""FastAPI router exposing an OpenAI AgentKit bridge."""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - standard runtime import
+    from fastapi import APIRouter, HTTPException
+    from fastapi.responses import JSONResponse
+except Exception:  # pragma: no cover - tests stub out fastapi
+    class HTTPException(Exception):  # type: ignore[misc, override]
+        def __init__(self, status_code: int, detail: Any):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class APIRouter:  # type: ignore[override]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.routes: List[Any] = []
+
+        def post(self, _path: str, **_kwargs: Any):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    class JSONResponse(dict):  # type: ignore[override]
+        def __init__(self, *, content: Dict[str, Any], status_code: int = 200) -> None:
+            super().__init__(content)
+            self.status_code = status_code
+
+from pydantic import BaseModel, Field
+
+from . import tools
+
+try:  # pragma: no cover - exercised at runtime
+    from openai import OpenAI
+except Exception:  # pragma: no cover - defensive: SDK might be missing
+    OpenAI = None  # type: ignore
+
+
+router = APIRouter(prefix="/agent", tags=["agent"])
+
+_DEFAULT_AGENT_MODEL = os.getenv("AGENTKIT_MODEL", os.getenv("LLM_MODEL", "gpt-4.1-mini"))
+_AGENT_INSTRUCTIONS = (
+    "You are Scout's analytics copilot. Use the provided tools to compile "
+    "natural language analytics questions into SQL and concise summaries. "
+    "Always reply with strictly valid JSON matching the schema: "
+    "{\"table\": [...], \"chart\": {...}, \"sql\": \"...\", \"summary\": \"...\", \"warnings\": []}. "
+    "Never hallucinate values; prefer returning warnings when data is missing."
+)
+
+_TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "compile_plan_and_query",
+            "description": "Compile a natural language question into SQL and deterministic records.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "Original user utterance to analyse.",
+                    },
+                    "prefer_llm": {
+                        "type": "boolean",
+                        "description": "Force enabling the LLM-based planner even when disabled globally.",
+                    },
+                },
+                "required": ["question"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "summarize_and_validate",
+            "description": "Summarise tabular results and surface guardrail warnings.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "plan": {
+                        "type": "object",
+                        "description": "Resolved analytics plan returned by the compiler tool.",
+                    },
+                    "records": {
+                        "type": "array",
+                        "description": "Records returned by the DuckDB execution stage.",
+                        "items": {"type": "object"},
+                    },
+                    "sql": {
+                        "type": "string",
+                        "description": "SQL statement used to generate the records.",
+                    },
+                },
+                "required": ["plan", "records"],
+            },
+        },
+    },
+]
+
+
+class AgentRequest(BaseModel):
+    """Inbound payload received from ChatKit."""
+
+    message: str = Field(..., description="Latest user utterance.")
+    thread_id: Optional[str] = Field(None, description="Existing OpenAI thread identifier.")
+    session_id: Optional[str] = Field(
+        None,
+        description="Opaque ChatKit session identifier used to restore threads between requests.",
+    )
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional context to persist with the thread.")
+    model: Optional[str] = Field(None, description="Override OpenAI model to use for the agent run.")
+
+
+class AgentResponse(BaseModel):
+    """Response returned to ChatKit."""
+
+    thread_id: str
+    table: List[Dict[str, Any]]
+    chart: Dict[str, Any]
+    sql: str
+    summary: str
+    warnings: List[str]
+
+
+class _ThreadStore:
+    """Simple in-memory persistence of thread ids keyed by session id."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._threads: Dict[str, str] = {}
+
+    def get(self, session_id: Optional[str]) -> Optional[str]:
+        if not session_id:
+            return None
+        with self._lock:
+            return self._threads.get(session_id)
+
+    def set(self, session_id: Optional[str], thread_id: str) -> None:
+        if not session_id:
+            return
+        with self._lock:
+            self._threads[session_id] = thread_id
+
+
+_thread_store = _ThreadStore()
+_assistant_cache: Dict[str, str] = {}
+_assistant_lock = threading.Lock()
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, default=str, sort_keys=True)
+
+
+def _ensure_client() -> Any:
+    if OpenAI is None:
+        raise HTTPException(status_code=503, detail="openai SDK is not installed")
+    try:
+        return OpenAI()
+    except Exception as exc:  # pragma: no cover - network/init errors
+        raise HTTPException(status_code=503, detail=f"Failed to initialise OpenAI client: {exc}") from exc
+
+
+def _ensure_agent(client: Any, model: str) -> str:
+    with _assistant_lock:
+        cached = _assistant_cache.get(model)
+        if cached:
+            return cached
+        assistant = client.beta.assistants.create(
+            name="Scout Analytics Agent",
+            instructions=_AGENT_INSTRUCTIONS,
+            model=model,
+            tools=_TOOL_DEFINITIONS,
+        )
+        _assistant_cache[model] = assistant.id
+        return assistant.id
+
+
+def _resolve_thread(client: Any, payload: AgentRequest) -> str:
+    thread_id = payload.thread_id or _thread_store.get(payload.session_id)
+    if thread_id:
+        return thread_id
+    metadata = payload.metadata.copy()
+    if payload.session_id:
+        metadata.setdefault("session_id", payload.session_id)
+    thread = client.beta.threads.create(metadata=metadata or None)
+    _thread_store.set(payload.session_id, thread.id)
+    return thread.id
+
+
+def _dispatch_tool_call(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    if name == "compile_plan_and_query":
+        result = tools.compile_plan_and_query(**arguments)
+        return result.dict()
+    if name == "summarize_and_validate":
+        result = tools.summarize_and_validate(**arguments)
+        return result.dict()
+    raise HTTPException(status_code=500, detail=f"Unsupported tool invocation: {name}")
+
+
+def _collect_assistant_reply(client: Any, thread_id: str) -> Dict[str, Any]:
+    messages = client.beta.threads.messages.list(thread_id=thread_id, order="desc", limit=1)
+    if not messages.data:
+        raise HTTPException(status_code=500, detail="Agent did not return a response")
+    message = messages.data[0]
+    buffer: List[str] = []
+    for part in message.content:
+        if getattr(part, "type", None) == "text":
+            buffer.append(part.text.value)
+    raw_text = "".join(buffer).strip()
+    if not raw_text:
+        raise HTTPException(status_code=500, detail="Agent response was empty")
+    try:
+        parsed = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=500, detail=f"Agent response was not valid JSON: {exc}") from exc
+    for key in ("table", "chart", "sql", "summary", "warnings"):
+        if key not in parsed:
+            raise HTTPException(status_code=500, detail=f"Agent response missing key: {key}")
+    return parsed
+
+
+def _run_agent(client: Any, assistant_id: str, thread_id: str, payload: AgentRequest) -> Dict[str, Any]:
+    client.beta.threads.messages.create(
+        thread_id=thread_id,
+        role="user",
+        content=payload.message,
+    )
+    run = client.beta.threads.runs.create(
+        thread_id=thread_id,
+        assistant_id=assistant_id,
+    )
+    while True:
+        run = client.beta.threads.runs.retrieve(thread_id=thread_id, run_id=run.id)
+        status = getattr(run, "status", None)
+        if status in {"queued", "in_progress"}:
+            time.sleep(0.3)
+            continue
+        if status == "requires_action":
+            required = getattr(run, "required_action", None)
+            if not required:
+                raise HTTPException(status_code=500, detail="Agent run requires action without tool calls")
+            tool_calls = getattr(required.submit_tool_outputs, "tool_calls", [])
+            outputs = []
+            for call in tool_calls:
+                name = getattr(call.function, "name", "")
+                arguments_json = getattr(call.function, "arguments", "{}")
+                try:
+                    arguments = json.loads(arguments_json)
+                except json.JSONDecodeError as exc:
+                    raise HTTPException(status_code=400, detail=f"Invalid tool arguments: {exc}") from exc
+                result = _dispatch_tool_call(name, arguments)
+                outputs.append({"tool_call_id": call.id, "output": _json_dumps(result)})
+            run = client.beta.threads.runs.submit_tool_outputs(
+                thread_id=thread_id,
+                run_id=run.id,
+                tool_outputs=outputs,
+            )
+            continue
+        if status == "completed":
+            return _collect_assistant_reply(client, thread_id)
+        if status in {"failed", "cancelled", "expired"}:
+            raise HTTPException(status_code=500, detail=f"Agent run terminated with status={status}")
+        time.sleep(0.3)
+
+
+@router.post("", response_model=AgentResponse)
+def agent_entrypoint(payload: AgentRequest) -> JSONResponse:
+    """Primary endpoint consumed by ChatKit."""
+
+    client = _ensure_client()
+    model = payload.model or _DEFAULT_AGENT_MODEL
+    assistant_id = _ensure_agent(client, model)
+    thread_id = _resolve_thread(client, payload)
+    _thread_store.set(payload.session_id, thread_id)
+
+    response_payload = _run_agent(client, assistant_id, thread_id, payload)
+    response_payload_sorted = json.loads(_json_dumps(response_payload))
+    response_payload_sorted["thread_id"] = thread_id
+
+    validated = AgentResponse(thread_id=thread_id, **response_payload_sorted)
+    return JSONResponse(content=json.loads(_json_dumps(validated.dict())))
+
+
+__all__ = ["router"]

--- a/nl-poc/app/agentkit/tools.py
+++ b/nl-poc/app/agentkit/tools.py
@@ -1,0 +1,146 @@
+"""Utility tools exposed to the AgentKit layer.
+
+The tools deliberately wrap the existing deterministic NQL pipeline so that the
+OpenAI Agent can orchestrate conversations without bypassing the carefully
+curated execution path. Each tool returns plain JSON-serialisable structures and
+keeps the behaviour of the legacy ``/ask`` and ``/chat`` routes intact.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Iterable, List, Optional
+
+from pydantic import BaseModel, Field
+
+from ..planner import build_plan, get_last_intent_engine
+from ..summarizer import HallucinationError, SummarizerError, summarize_results
+from ..viz import build_narrative, choose_chart
+
+
+class QueryCompilationResult(BaseModel):
+    """Structured representation returned by ``compile_plan_and_query``."""
+
+    question: str = Field(..., description="Natural language question supplied by the user.")
+    plan: Dict[str, Any] = Field(..., description="Resolved analytics plan ready for SQL compilation.")
+    sql: str = Field(..., description="Deterministic SELECT query executed against DuckDB.")
+    table: List[Dict[str, Any]] = Field(..., description="Tabular result rows returned by DuckDB.")
+    chart: Dict[str, Any] = Field(..., description="Chart recommendation derived from the semantic plan.")
+    summary: str = Field(..., description="Single sentence summary describing the key insight.")
+    warnings: List[str] = Field(default_factory=list, description="Non fatal warnings produced by guardrails.")
+
+
+class SummaryResult(BaseModel):
+    """Response envelope for ``summarize_and_validate`` outputs."""
+
+    summary: str = Field(..., description="Narrative explanation of the result set.")
+    chart: Dict[str, Any] = Field(..., description="Renderable chart specification.")
+    warnings: List[str] = Field(default_factory=list, description="Additional warning messages emitted by guardrails.")
+
+
+def _get_main_module():
+    """Import ``app.main`` lazily to avoid circular import issues."""
+
+    from .. import main as main_app  # Local import keeps module import order intact.
+
+    return main_app
+
+
+def _ensure_runtime_dependencies(main_app: Any) -> None:
+    """Validate that the FastAPI application has initialised its shared state."""
+
+    missing: List[str] = []
+    for key in ("executor", "resolver", "semantic"):
+        if key not in main_app._state:  # type: ignore[attr-defined]
+            missing.append(key)
+    if missing:
+        raise RuntimeError(
+            "Application state has not been initialised; missing: " + ", ".join(sorted(missing))
+        )
+
+
+def _execute_with_legacy_pipeline(plan: Dict[str, Any], question: str, *, intent_engine: str) -> Dict[str, Any]:
+    """Proxy to the existing execution helper defined in ``app.main``."""
+
+    main_app = _get_main_module()
+    _ensure_runtime_dependencies(main_app)
+    return main_app._execute_query(plan, question, intent_engine=intent_engine)  # type: ignore[attr-defined]
+
+
+def compile_plan_and_query(
+    *,
+    question: str,
+    prefer_llm: Optional[bool] = None,
+) -> QueryCompilationResult:
+    """Convert natural language into deterministic analytics output.
+
+    The function mirrors the behaviour of ``/ask`` while returning a compact
+    response envelope that the AgentKit runtime can reason about.  All heavy
+    lifting is delegated to the existing planner/SQL builder so no additional
+    logic is duplicated.
+    """
+
+    cleaned_question = (question or "").strip()
+    if not cleaned_question:
+        raise ValueError("Question must be a non-empty string.")
+
+    plan = build_plan(cleaned_question, prefer_llm=prefer_llm)
+    intent_engine = get_last_intent_engine()
+    execution = _execute_with_legacy_pipeline(plan, cleaned_question, intent_engine=intent_engine)
+
+    result = QueryCompilationResult(
+        question=cleaned_question,
+        plan=execution.get("plan", {}),
+        sql=execution.get("sql", ""),
+        table=execution.get("table", []),
+        chart=execution.get("chart", {}),
+        summary=execution.get("answer", ""),
+        warnings=list(execution.get("warnings", []) or []),
+    )
+    return result
+
+
+def summarize_and_validate(
+    *,
+    plan: Dict[str, Any],
+    records: Iterable[Dict[str, Any]],
+    sql: str = "",
+) -> SummaryResult:
+    """Produce a narrative summary while surfacing validation warnings.
+
+    ``records`` may be any iterable of dictionaries; it is eagerly materialised
+    to ensure deterministic iteration order for JSON serialisation.
+    """
+
+    materialised_records = [dict(row) for row in records]
+
+    chart = choose_chart(plan, materialised_records)
+    narrative = build_narrative(plan, materialised_records)
+    warnings: List[str] = []
+
+    use_summarizer = os.getenv("USE_SUMMARIZER", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+    if use_summarizer:
+        try:
+            summary_blob = summarize_results(materialised_records, plan)
+        except (SummarizerError, HallucinationError):
+            # Fall back to deterministic narrative on summariser failures.  The
+            # legacy guardrails expect a warning to be propagated back to the user.
+            warnings.append("llm_summarizer_unavailable")
+            summary_text = narrative
+        else:
+            summary_text = summary_blob.get("explanation") or narrative
+            extra_warnings = summary_blob.get("warnings")
+            if isinstance(extra_warnings, list):
+                warnings.extend(str(w) for w in extra_warnings if w)
+    else:
+        summary_text = narrative
+
+    payload = SummaryResult(summary=summary_text, chart=chart, warnings=warnings)
+    return payload
+
+
+__all__ = ["compile_plan_and_query", "summarize_and_validate", "QueryCompilationResult", "SummaryResult"]

--- a/nl-poc/app/main.py
+++ b/nl-poc/app/main.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from . import guardrails, sql_builder, viz
+from .agentkit import router as agentkit_router
 from .admin.canonical import api_router as canonical_api_router
 from .admin.canonical import router as canonical_admin_router
 from .canonical import CanonicalStore, CanonicalWatcher
@@ -94,6 +95,7 @@ if hasattr(app, "include_router"):
     app.include_router(feedback_router)
     app.include_router(canonical_admin_router)
     app.include_router(canonical_api_router)
+    app.include_router(agentkit_router)
 
 _state: Dict[str, Any] = {
     "last_debug": None,

--- a/nl-poc/frontend/chatkit-agent.js
+++ b/nl-poc/frontend/chatkit-agent.js
@@ -1,0 +1,49 @@
+// Minimal ChatKit integration for the AgentKit backend bridge.
+//
+// The helper keeps the OpenAI thread identifier in localStorage so the
+// conversation persists across reloads.
+
+const THREAD_STORAGE_KEY = 'scout-agent-thread-id';
+
+export async function sendAgentMessage(message, sessionId) {
+  if (!message || !message.trim()) {
+    throw new Error('Message cannot be empty');
+  }
+
+  const payload = {
+    message: message.trim(),
+    session_id: sessionId || null,
+    thread_id: localStorage.getItem(THREAD_STORAGE_KEY) || null,
+  };
+
+  const response = await fetch('/agent', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: response.statusText }));
+    throw new Error(error.detail || 'Agent request failed');
+  }
+
+  const data = await response.json();
+  if (data.thread_id) {
+    localStorage.setItem(THREAD_STORAGE_KEY, data.thread_id);
+  }
+
+  return {
+    threadId: data.thread_id,
+    table: data.table,
+    chart: data.chart,
+    sql: data.sql,
+    summary: data.summary,
+    warnings: data.warnings || [],
+  };
+}
+
+export function resetAgentThread() {
+  localStorage.removeItem(THREAD_STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
- add a dedicated `app.agentkit` package with tools that reuse the existing deterministic NQL execution path
- expose a new `/agent` FastAPI endpoint that brokers OpenAI AgentKit runs, registers the tools, and manages thread persistence
- provide a front-end helper that keeps the ChatKit thread ID in localStorage and posts user utterances to the backend
- wire the new router into the FastAPI application so the agent endpoint is served alongside existing routes

## Testing
- `pytest tests/test_nql_gate.py -q` *(fails: fastapi test stub lacks APIRouter when importing the new agent package)*

------
https://chatgpt.com/codex/tasks/task_e_68e44e660fc0832e8f9cc18dd2e27fa1