### PR TITLE
Add fallback manual chat UI when ChatKit widget fails

### DIFF
--- a/app/api/manual-chat/route.ts
+++ b/app/api/manual-chat/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function resolveSessionId(candidate: unknown): string | undefined {
+  if (typeof candidate === 'string' && candidate.trim().length > 0) {
+    return candidate.trim();
+  }
+  return undefined;
+}
+
+export async function POST(req: NextRequest) {
+  const backendBase = process.env.BACKEND_BASE_URL;
+  if (!backendBase) {
+    return NextResponse.json({ error: 'backend_not_configured' }, { status: 500 });
+  }
+
+  const body = await req.json().catch(() => ({} as Record<string, unknown>));
+  const sessionId = resolveSessionId(body?.sessionId);
+  const clarification = typeof body?.clarification === 'string' ? body.clarification.trim() : '';
+  const question = typeof body?.question === 'string' ? body.question.trim() : '';
+  const contextEnabled = typeof body?.contextEnabled === 'boolean' ? body.contextEnabled : true;
+
+  if (!sessionId) {
+    return NextResponse.json({ error: 'missing_session' }, { status: 400 });
+  }
+
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  headers.set('X-Session-Id', sessionId);
+
+  const targetPath = clarification ? '/chat/clarify' : '/chat/complete';
+  const payload = clarification
+    ? { session_id: sessionId, answer: clarification }
+    : { session_id: sessionId, utterance: question, context_enabled: contextEnabled };
+
+  if (!clarification && !question) {
+    return NextResponse.json({ error: 'question_required' }, { status: 400 });
+  }
+
+  const target = new URL(targetPath, backendBase);
+
+  try {
+    const response = await fetch(target, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : {};
+
+    if (response.status === 409) {
+      const detail = data?.detail ?? data;
+      if (detail && typeof detail === 'object' && 'question' in detail) {
+        return NextResponse.json({
+          status: 'clarification_needed',
+          clarification: {
+            question: String(detail.question ?? ''),
+            suggested_answers: Array.isArray(detail.suggested_answers) ? detail.suggested_answers : [],
+          },
+        });
+      }
+      const message = typeof detail?.message === 'string' ? detail.message : 'conflict';
+      return NextResponse.json({ error: message, detail }, { status: response.status });
+    }
+
+    if (!response.ok) {
+      const detail = data?.detail ?? data;
+      const message = typeof detail === 'string' ? detail : detail?.message ?? response.statusText;
+      return NextResponse.json({ error: message, detail }, { status: response.status });
+    }
+
+    if (data?.status === 'clarification_needed' && data?.question) {
+      return NextResponse.json({
+        status: 'clarification_needed',
+        clarification: {
+          question: String(data.question),
+          suggested_answers: Array.isArray(data.suggested_answers) ? data.suggested_answers : [],
+        },
+      });
+    }
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'manual_chat_failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { ChatKit, useChatKit } from '@openai/chatkit-react';
 
 type ResultPayload = {
+  answer?: string;
   chart?: Record<string, unknown>;
   plan?: Record<string, unknown>;
   rowcount?: number;
@@ -19,6 +20,104 @@ type ChatKitLogEvent = {
   data?: Record<string, unknown>;
   timestamp: number;
 };
+
+type ManualChatResponse = {
+  answer?: string;
+  chart?: Record<string, unknown>;
+  plan?: Record<string, unknown>;
+  sql?: string;
+  summary?: string;
+  table?: Array<Record<string, unknown>>;
+  warnings?: string[];
+};
+
+const CHATKIT_SCRIPT_URL = process.env.NEXT_PUBLIC_CHATKIT_SCRIPT_URL ??
+  'https://cdn.openai.com/chatkit/latest/chatkit.js';
+
+function loadChatKitScript(url: string): Promise<void> {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return Promise.resolve();
+  }
+
+  if (!url) {
+    return Promise.reject(new Error('No ChatKit script URL configured.'));
+  }
+
+  const existingElement = document.querySelector<HTMLScriptElement>(
+    `script[data-chatkit-src="${url}"]`,
+  );
+
+  if (existingElement?.dataset.loaded === 'true') {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const script = existingElement ?? document.createElement('script');
+    script.async = true;
+    script.src = url;
+    script.dataset.chatkitSrc = url;
+
+    const handleLoad = () => {
+      script.dataset.loaded = 'true';
+      resolve();
+    };
+
+    const handleError = () => {
+      reject(new Error(`Failed to load ChatKit script from ${url}`));
+    };
+
+    script.addEventListener('load', handleLoad, { once: true });
+    script.addEventListener('error', handleError, { once: true });
+
+    if (!existingElement) {
+      document.head.appendChild(script);
+    }
+  });
+}
+
+function useChatKitAvailability() {
+  const [status, setStatus] = React.useState<'loading' | 'ready' | 'unavailable'>(() => {
+    if (typeof window === 'undefined') {
+      return 'loading';
+    }
+    return window.customElements?.get('openai-chatkit') ? 'ready' : 'loading';
+  });
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let cancelled = false;
+
+    async function ensureChatKit() {
+      if (window.customElements?.get('openai-chatkit')) {
+        setStatus('ready');
+        return;
+      }
+
+      try {
+        await loadChatKitScript(CHATKIT_SCRIPT_URL);
+        await window.customElements.whenDefined('openai-chatkit');
+        if (!cancelled) {
+          setStatus('ready');
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'ChatKit unavailable';
+        if (!cancelled) {
+          setError(message);
+          setStatus('unavailable');
+        }
+      }
+    }
+
+    ensureChatKit();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { status, error };
+}
 
 function isResultPayload(candidate: unknown): candidate is ResultPayload {
   if (!candidate || typeof candidate !== 'object') {
@@ -75,6 +174,12 @@ function ResultCards({ payload }: { payload: ResultPayload }) {
   if (!payload) return null;
   return (
     <div className="space-y-3">
+      {payload.answer && (
+        <div className="rounded-2xl border p-3">
+          <h3 className="font-semibold">Answer</h3>
+          <p>{payload.answer}</p>
+        </div>
+      )}
       {payload.summary && (
         <div className="rounded-2xl border p-3">
           <h3 className="font-semibold">Summary</h3>
@@ -135,7 +240,218 @@ function ResultCards({ payload }: { payload: ResultPayload }) {
   );
 }
 
-export default function ChatPanel() {
+function FallbackChatPanel({ reason }: { reason: string }) {
+  const [question, setQuestion] = React.useState('');
+  const [contextEnabled, setContextEnabled] = React.useState(true);
+  const [pendingClarification, setPendingClarification] = React.useState<{
+    question: string;
+    options: string[];
+  } | null>(null);
+  const [result, setResult] = React.useState<ResultPayload | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [history, setHistory] = React.useState<string[]>([]);
+  const sessionIdRef = React.useRef<string>('');
+  if (!sessionIdRef.current) {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      sessionIdRef.current = crypto.randomUUID();
+    } else {
+      sessionIdRef.current = `session-${Math.random().toString(36).slice(2)}`;
+    }
+  }
+
+  const persistHistory = React.useCallback((entry: string) => {
+    setHistory((prev) => {
+      const next = [entry, ...prev.filter((item) => item !== entry)];
+      return next.slice(0, 8);
+    });
+  }, []);
+
+  const coerceManualPayload = React.useCallback((data: ManualChatResponse | null | undefined): ResultPayload | null => {
+    if (!data) return null;
+    return {
+      answer: typeof data.answer === 'string' ? data.answer : undefined,
+      summary: typeof data.summary === 'string' ? data.summary : undefined,
+      sql: typeof data.sql === 'string' ? data.sql : undefined,
+      chart: typeof data.chart === 'object' ? data.chart ?? undefined : undefined,
+      plan: typeof data.plan === 'object' ? data.plan ?? undefined : undefined,
+      table: Array.isArray(data.table) ? data.table : undefined,
+      warnings: Array.isArray(data.warnings) ? data.warnings : undefined,
+    } satisfies ResultPayload;
+  }, []);
+
+  const submit = React.useCallback(
+    async (utterance: string, clarificationAnswer?: string) => {
+      const trimmed = utterance.trim();
+      if (!trimmed) {
+        setError('Please enter a question.');
+        return;
+      }
+      setError(null);
+      setLoading(true);
+      try {
+        const res = await fetch('/api/manual-chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: sessionIdRef.current,
+            question: clarificationAnswer ? undefined : trimmed,
+            clarification: clarificationAnswer ?? null,
+            contextEnabled,
+          }),
+        });
+
+        if (!res.ok) {
+          const detail = await res.json().catch(() => ({}));
+          const message = detail?.error || detail?.detail || res.statusText || 'Request failed';
+          throw new Error(message);
+        }
+
+        const payload = (await res.json()) as {
+          status?: string;
+          data?: ManualChatResponse;
+          clarification?: {
+            question: string;
+            suggested_answers?: string[];
+          };
+        };
+
+        if (payload.status === 'clarification_needed' && payload.clarification) {
+          setPendingClarification({
+            question: payload.clarification.question,
+            options: payload.clarification.suggested_answers ?? [],
+          });
+          setResult(null);
+        } else if (payload.data) {
+          setPendingClarification(null);
+          const coerced = coerceManualPayload(payload.data);
+          setResult(coerced);
+          if (!clarificationAnswer) {
+            persistHistory(trimmed);
+          }
+          setQuestion('');
+        } else {
+          throw new Error('Unexpected response from the backend');
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Something went wrong';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [contextEnabled, coerceManualPayload, persistHistory],
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-dashed bg-orange-50 p-4 text-sm text-orange-900">
+        <p className="font-semibold">Chat interface fallback</p>
+        <p>
+          The ChatKit widget could not be loaded ({reason}). You can continue by using the lightweight
+          text interface below. Configure <code>NEXT_PUBLIC_CHATKIT_SCRIPT_URL</code> to re-enable the full
+          chat experience.
+        </p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-4">
+          <div className="rounded-2xl border p-4">
+            <label className="block text-sm font-medium" htmlFor="fallback-question">
+              Ask a question
+            </label>
+            <textarea
+              id="fallback-question"
+              className="mt-2 h-32 w-full resize-y rounded-lg border p-2 text-sm focus:border-blue-500 focus:outline-none"
+              placeholder="e.g. How many incidents were reported last month?"
+              value={question}
+              onChange={(event) => setQuestion(event.target.value)}
+              disabled={loading}
+            />
+            <div className="mt-3 flex items-center justify-between gap-3">
+              <button
+                type="button"
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:bg-blue-300"
+                onClick={() => submit(question, pendingClarification ? question : undefined)}
+                disabled={loading}
+              >
+                {loading ? 'Submitting…' : 'Run analysis'}
+              </button>
+              <label className="flex items-center gap-2 text-xs text-neutral-600">
+                <input
+                  type="checkbox"
+                  checked={contextEnabled}
+                  onChange={(event) => setContextEnabled(event.target.checked)}
+                />
+                Keep conversation context
+              </label>
+            </div>
+            {error ? (
+              <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-2 text-sm text-red-700">
+                {error}
+              </div>
+            ) : null}
+            {pendingClarification ? (
+              <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                <p className="font-semibold">Clarification needed</p>
+                <p className="mt-1">{pendingClarification.question}</p>
+                <p className="mt-1 text-xs text-amber-800">
+                  Choose one of the suggestions below or type your own answer above and run it again.
+                </p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {pendingClarification.options.map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      className="rounded-full border border-amber-400 px-3 py-1 text-xs"
+                      onClick={() => {
+                        setQuestion(option);
+                        submit(option, option);
+                      }}
+                      disabled={loading}
+                    >
+                      {option}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+          {history.length > 0 ? (
+            <div className="rounded-2xl border p-4">
+              <h3 className="text-sm font-semibold">Recent questions</h3>
+              <ul className="mt-2 space-y-1 text-xs text-neutral-600">
+                {history.map((item) => (
+                  <li key={item}>
+                    <button
+                      type="button"
+                      className="hover:text-neutral-900"
+                      onClick={() => {
+                        setQuestion(item);
+                        submit(item);
+                      }}
+                    >
+                      {item}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+        <div className="rounded-2xl border p-4">
+          <h2 className="mb-2 font-semibold">Results</h2>
+          {result ? (
+            <ResultCards payload={result} />
+          ) : (
+            <p className="text-sm text-neutral-500">Submit a question to see results.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChatKitPanel() {
   const [threadId, setThreadId] = React.useState<string | null>(() => {
     return typeof window !== 'undefined' ? localStorage.getItem('truesight_thread_id') : null;
   });
@@ -252,4 +568,22 @@ export default function ChatPanel() {
       </div>
     </div>
   );
+}
+
+export default function ChatPanel() {
+  const { status, error } = useChatKitAvailability();
+
+  if (status === 'loading') {
+    return (
+      <div className="rounded-2xl border p-6 text-sm text-neutral-600">
+        Preparing chat interface…
+      </div>
+    );
+  }
+
+  if (status === 'unavailable') {
+    return <FallbackChatPanel reason={error ?? 'ChatKit unavailable'} />;
+  }
+
+  return <ChatKitPanel />;
 }


### PR DESCRIPTION
## Summary
- add runtime detection for the ChatKit web component and expose a fallback chat experience when it is unavailable
- extend the chat panel with a lightweight manual input workflow, including clarification handling and recent history
- add a Next.js API route that proxies chat and clarification requests to the backend for the fallback UI

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e47cb609ac832e95af9336b171c9d5