### PR TITLE
Fix ChatKit session endpoint and React integration

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,167 +1,63 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { ChatKit, useChatKit } from "@openai/chatkit-react";
+import { useState } from "react";
 
-const DEFAULT_CHATKIT_SCRIPT_URL =
-  "https://cdn.platform.openai.com/deployments/chatkit/chatkit.js";
-
-type ChatKitConstructor = new (config: { clientSecret: string }) => {
-  mount: (selector: string) => void;
-  unmount?: () => void;
+type SessionResponse = {
+  client_secret?: string;
 };
 
-declare global {
-  interface Window {
-    ChatKit?: ChatKitConstructor;
-  }
-}
-
-export default function ChatPanel() {
+export function ChatPanel() {
   const [error, setError] = useState<string | null>(null);
-  const chatkitRef = useRef<{ unmount?: () => void } | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const { control } = useChatKit({
+    api: {
+      async getClientSecret(existingClientSecret: string | null) {
+        try {
+          const response = await fetch("/api/chatkit/session", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          });
 
-    async function init() {
-      try {
-        const response = await fetch("/api/chatkit/start", { method: "POST" });
+          if (!response.ok) {
+            const message = await response.text();
+            throw new Error(
+              message || `Failed to fetch ChatKit client secret (${response.status}).`,
+            );
+          }
 
-        if (!response.ok) {
-          const errorBody = await response.text();
-          throw new Error(errorBody || "Failed to create ChatKit session.");
+          const { client_secret: clientSecret } = (await response.json()) as SessionResponse;
+
+          if (typeof clientSecret !== "string" || clientSecret.length === 0) {
+            throw new Error("ChatKit session response missing client_secret.");
+          }
+
+          setError(null);
+          return clientSecret;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Unknown error";
+          console.error("ChatKit getClientSecret failed", {
+            error: err,
+            hasExistingClientSecret: Boolean(existingClientSecret),
+          });
+          setError(message);
+          throw err;
         }
-
-        const { client_secret: clientSecret } = (await response.json()) as {
-          client_secret?: string;
-        };
-
-        if (!clientSecret) {
-          throw new Error("ChatKit session response missing client_secret.");
-        }
-
-        if (cancelled) return;
-
-        await loadChatKitScript();
-
-        if (cancelled) return;
-
-        if (!window.ChatKit) {
-          throw new Error("ChatKit script did not load correctly.");
-        }
-
-        const instance = new window.ChatKit({ clientSecret });
-        instance.mount("#chat-container");
-        chatkitRef.current = instance;
-        setError(null);
-      } catch (err) {
-        if (cancelled) return;
-        const message = err instanceof Error ? err.message : "Unknown error";
-        console.error("ChatKit init failed", err);
-        setError(message);
-      }
-    }
-
-    init();
-
-    return () => {
-      cancelled = true;
-      if (chatkitRef.current?.unmount) {
-        chatkitRef.current.unmount();
-      }
-      chatkitRef.current = null;
-    };
-  }, []);
+      },
+    },
+  });
 
   return (
-    <div className="w-full h-[600px] border rounded-xl overflow-hidden">
+    <div className="h-[600px] w-[400px]">
       {error ? (
-        <div className="flex h-full items-center justify-center bg-red-50 text-red-600 p-4 text-center text-sm">
+        <div className="flex h-full items-center justify-center rounded-xl border border-red-200 bg-red-50 p-4 text-center text-sm text-red-600">
           {error}
         </div>
       ) : (
-        <div id="chat-container" className="w-full h-full" />
+        <ChatKit control={control} className="h-full w-full" />
       )}
     </div>
   );
 }
 
-async function loadChatKitScript() {
-  const url =
-    process.env.NEXT_PUBLIC_CHATKIT_SCRIPT_URL || DEFAULT_CHATKIT_SCRIPT_URL;
-
-  console.log("Loading ChatKit from:", url);
-
-  if (typeof window === "undefined" || typeof document === "undefined") {
-    return;
-  }
-
-  if (window.ChatKit) {
-    console.log("ChatKit already loaded");
-    return;
-  }
-
-  const existingScript = document.getElementById("chatkit-script");
-  if (existingScript) {
-    console.log("ChatKit script tag exists, waiting for window.ChatKit...");
-    await waitForChatKit();
-    return;
-  }
-
-  await new Promise<void>((resolve, reject) => {
-    const script = document.createElement("script");
-    script.id = "chatkit-script";
-    script.src = url;
-    script.async = true;
-    script.onload = () => {
-      console.log("ChatKit script loaded successfully");
-      console.log("window.ChatKit available:", !!window.ChatKit);
-      console.log("window keys:", Object.keys(window).filter(k => k.toLowerCase().includes('chat')));
-      resolve();
-    };
-    script.onerror = (e) => {
-      console.error("ChatKit script load error:", e);
-      reject(new Error("Failed to load ChatKit script."));
-    };
-    document.body.appendChild(script);
-  });
-
-  await waitForChatKit();
-}
-
-function waitForChatKit() {
-  return new Promise<void>((resolve, reject) => {
-    if (window.ChatKit) {
-      console.log("ChatKit found immediately");
-      resolve();
-      return;
-    }
-
-    console.log("Waiting for window.ChatKit to become available...");
-    let checks = 0;
-
-    const timeout = window.setTimeout(() => {
-      console.error(`ChatKit timed out after ${checks} checks`);
-      console.error("window.ChatKit:", window.ChatKit);
-      console.error("Available window properties:", Object.keys(window).filter(k => k.toLowerCase().includes('chat')));
-      reject(new Error("ChatKit script timed out while loading. Check browser console for details."));
-    }, 30000); // Increased to 30 seconds for debugging
-
-    const check = () => {
-      checks++;
-      if (checks % 10 === 0) {
-        console.log(`Still waiting for ChatKit... (${checks} checks)`);
-      }
-
-      if (window.ChatKit) {
-        console.log("ChatKit found after", checks, "checks");
-        window.clearTimeout(timeout);
-        resolve();
-      } else {
-        requestAnimationFrame(check);
-      }
-    };
-
-    check();
-  });
-}
+export default ChatPanel;


### PR DESCRIPTION
## Summary
- replace the chat session API route to call the OpenAI ChatKit sessions endpoint with the required headers and payload
- refactor the ChatPanel component to use the @openai/chatkit-react bindings instead of the CDN script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e599512c0c832ea2161659e1fa03f3