### PR TITLE
Add insight panel with chart and table renderers

### DIFF
--- a/app/components/ChartRenderer.tsx
+++ b/app/components/ChartRenderer.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  LineElement,
+  PointElement,
+  Tooltip,
+  Legend,
+  ChartOptions,
+  ChartData,
+} from "chart.js";
+import { Bar, Line } from "react-chartjs-2";
+import { useMemo } from "react";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, LineElement, PointElement, Tooltip, Legend);
+
+export type ChartRow = Record<string, unknown>;
+
+export type InsightChart = {
+  type?: string;
+  x: string;
+  y: string;
+  data?: ChartRow[];
+};
+
+export type ChartRendererProps = {
+  chart: InsightChart | null | undefined;
+};
+
+function formatLabelValue(value: unknown, formatter: Intl.DateTimeFormat | null) {
+  if (formatter && typeof value === "string") {
+    const date = new Date(value);
+    if (!Number.isNaN(date.valueOf())) {
+      return formatter.format(date);
+    }
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value);
+}
+
+export function ChartRenderer({ chart }: ChartRendererProps) {
+  const { chartData, chartOptions, type } = useMemo(() => {
+    if (!chart || !Array.isArray(chart.data) || chart.data.length === 0) {
+      return { chartData: null, chartOptions: null, type: chart?.type ?? "bar" } as {
+        chartData: ChartData<"bar"> | ChartData<"line"> | null;
+        chartOptions: ChartOptions<"bar"> | ChartOptions<"line"> | null;
+        type: string;
+      };
+    }
+
+    const xKey = chart.x;
+    const yKey = chart.y;
+    const dateFormatter = chart.x === "month" ? new Intl.DateTimeFormat(undefined, { month: "short", year: "numeric" }) : null;
+    const labels = chart.data.map((row: ChartRow) => formatLabelValue(row[xKey], dateFormatter));
+    const values = chart.data.map((row: ChartRow) => {
+      const numeric = Number(row[yKey]);
+      return Number.isFinite(numeric) ? numeric : 0;
+    });
+
+    const datasetConfig =
+      chart.type === "line"
+        ? {
+            label: yKey,
+            data: values,
+            borderColor: "rgba(239, 68, 68, 1)",
+            backgroundColor: "rgba(239, 68, 68, 0.2)",
+            borderWidth: 2,
+            pointRadius: 4,
+            tension: 0.3,
+            fill: false,
+          }
+        : {
+            label: yKey,
+            data: values,
+            backgroundColor: "rgba(37, 99, 235, 0.6)",
+            borderColor: "rgba(37, 99, 235, 1)",
+            borderWidth: 1,
+            borderSkipped: false as const,
+          };
+
+    const options: ChartOptions<"bar"> | ChartOptions<"line"> = {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        tooltip: { enabled: true },
+        legend: { display: true },
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+        },
+      },
+    };
+
+    const data: ChartData<"bar"> | ChartData<"line"> = {
+      labels,
+      datasets: [datasetConfig],
+    };
+
+    return { chartData: data, chartOptions: options, type: chart.type ?? "bar" };
+  }, [chart]);
+
+  if (!chart || !chartData || !chartOptions) {
+    return (
+      <div className="mt-4 flex h-96 w-full items-center justify-center rounded-lg border border-dashed border-gray-200 bg-white text-sm text-gray-500">
+        No chart data available.
+      </div>
+    );
+  }
+
+  const ChartComponent = type === "line" ? Line : Bar;
+
+  return (
+    <div className="mt-4 h-96 w-full">
+      <ChartComponent data={chartData} options={chartOptions} />
+    </div>
+  );
+}
+
+export default ChartRenderer;

--- a/app/components/InsightPanel.tsx
+++ b/app/components/InsightPanel.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useMemo } from "react";
+import ChartRenderer, { InsightChart } from "./ChartRenderer";
+import TableRenderer from "./TableRenderer";
+
+type InsightChips = {
+  time?: string[];
+  dimensions?: string[];
+  filters?: string[];
+};
+
+type NqlStatus = {
+  valid?: boolean;
+  attempted?: boolean;
+  stage?: string;
+  reason?: string;
+  fallback?: string;
+  detail?: string;
+};
+
+export type InsightPanelData = {
+  summary?: string;
+  chart?: InsightChart | null;
+  table?: Array<Record<string, unknown>> | null;
+  sql?: string | null;
+  plan?: unknown;
+  lineage?: unknown;
+  warnings?: string[] | null;
+  status?: string | null;
+  followups?: string[] | null;
+  chips?: InsightChips | null;
+  nqlStatus?: NqlStatus | null;
+};
+
+export type InsightPanelProps = {
+  data: InsightPanelData | null;
+};
+
+function formatStructuredValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (err) {
+    return String(value);
+  }
+}
+
+function buildNqlStatusMessage(status: NqlStatus | null | undefined) {
+  if (!status) return null;
+  if (status.valid || status.valid === undefined) {
+    if (status.attempted === undefined && status.reason === undefined) {
+      return null;
+    }
+  }
+
+  if (status.attempted === false) {
+    const reason = status.reason || "nql_not_attempted";
+    return `NQL not used (${reason})`;
+  }
+
+  if (status.valid) {
+    return null;
+  }
+
+  const stage = status.stage ? status.stage.toUpperCase() : "UNKNOWN";
+  const reason = status.reason || "error";
+  const fallback = status.fallback ? status.fallback.toUpperCase() : "LEGACY";
+  return `NQL fallback (${stage}): ${reason} → ${fallback}`;
+}
+
+function renderChips(chips: InsightChips | null | undefined) {
+  if (!chips) return null;
+  const items: Array<{ label: string; value: string }> = [];
+
+  (chips.time ?? []).forEach((value) => items.push({ label: "Time", value }));
+  (chips.dimensions ?? []).forEach((value) => items.push({ label: "Dimensions", value }));
+  (chips.filters ?? []).forEach((value) => items.push({ label: "Filters", value }));
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="mt-4 flex flex-wrap gap-2">
+      {items.map((item, index) => (
+        <span
+          key={`${item.label}-${item.value}-${index}`}
+          className="inline-flex items-center rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+        >
+          <span className="mr-1 text-slate-500">{item.label}:</span>
+          {item.value}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function InsightPanel({ data }: InsightPanelProps) {
+  const warnings = useMemo(() => (Array.isArray(data?.warnings) ? data?.warnings.filter(Boolean) : []), [data?.warnings]);
+  const followups = useMemo(() => (Array.isArray(data?.followups) ? data?.followups.filter(Boolean) : []), [data?.followups]);
+  const needsClarification = data?.status === "clarification_needed";
+
+  const nqlStatusMessage = useMemo(() => buildNqlStatusMessage(data?.nqlStatus), [data?.nqlStatus]);
+
+  if (!data) {
+    return (
+      <div className="flex h-full flex-col rounded-xl border border-dashed border-gray-300 bg-white p-6 text-center text-sm text-gray-500 shadow-sm">
+        <div className="m-auto max-w-sm space-y-2">
+          <h2 className="text-lg font-semibold text-gray-700">Insight Panel</h2>
+          <p className="text-gray-500">Run a query in the chat to see visualizations and query details here.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const summary = data.summary?.trim();
+  const plan = formatStructuredValue(data.plan);
+  const lineage = formatStructuredValue(data.lineage);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-white shadow-sm">
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="space-y-6">
+          <header>
+            <h2 className="text-xl font-semibold text-gray-900">Insight</h2>
+            <p className="mt-2 text-base text-gray-700">{summary || "Awaiting the latest insight..."}</p>
+            {needsClarification ? (
+              <div className="mt-4 rounded-lg border border-indigo-300 bg-indigo-50 p-4 text-sm text-indigo-800">
+                <p className="font-medium">More detail is required to continue.</p>
+                <p className="mt-1 text-indigo-700">Respond in chat to clarify your request.</p>
+              </div>
+            ) : null}
+            {renderChips(data.chips ?? null)}
+            {followups.length > 0 ? (
+              <div className="mt-4">
+                <p className="text-sm font-medium text-gray-600">You might also ask:</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {followups.map((item, index) => (
+                    <span
+                      key={`${item}-${index}`}
+                      className="inline-flex items-center rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-700"
+                    >
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </header>
+
+          {nqlStatusMessage ? (
+            <div
+              className="rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-800"
+              title={data?.nqlStatus?.detail}
+            >
+              {nqlStatusMessage}
+            </div>
+          ) : null}
+
+          {warnings.length > 0 ? (
+            <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800">
+              <h3 className="mb-2 text-base font-semibold">⚠️ Warnings</h3>
+              <ul className="list-disc space-y-1 pl-5">
+                {warnings.map((warning, index) => (
+                  <li key={`${warning}-${index}`}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <section>
+            <h3 className="text-lg font-semibold text-gray-900">Chart</h3>
+            <ChartRenderer chart={data.chart ?? null} />
+          </section>
+
+          <section>
+            <h3 className="text-lg font-semibold text-gray-900">Table</h3>
+            <TableRenderer rows={data.table ?? null} />
+          </section>
+
+          <section>
+            <details className="group rounded-lg border border-gray-200 bg-gray-50 p-4" open>
+              <summary className="cursor-pointer text-base font-semibold text-gray-900">
+                How this was computed
+              </summary>
+              <div className="mt-4 space-y-4 text-sm">
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-800">SQL</h4>
+                  <pre className="mt-2 overflow-auto rounded-md bg-gray-900 p-4 text-xs text-gray-100">
+                    {data.sql || "No SQL available."}
+                  </pre>
+                </div>
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-800">Plan</h4>
+                  <pre className="mt-2 overflow-auto rounded-md bg-gray-900 p-4 text-xs text-gray-100">
+                    {plan || "No plan available."}
+                  </pre>
+                </div>
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-800">Lineage</h4>
+                  <pre className="mt-2 overflow-auto rounded-md bg-gray-900 p-4 text-xs text-gray-100">
+                    {lineage || "No lineage available."}
+                  </pre>
+                </div>
+              </div>
+            </details>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default InsightPanel;

--- a/app/components/TableRenderer.tsx
+++ b/app/components/TableRenderer.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+export type TableRendererProps = {
+  rows: Array<Record<string, unknown>> | null | undefined;
+};
+
+function normalizeRows(rows: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  return rows.map((row) => ({ ...row }));
+}
+
+export function TableRenderer({ rows }: TableRendererProps) {
+  if (!rows || rows.length === 0) {
+    return <p className="mt-4 text-sm text-gray-500">No rows returned.</p>;
+  }
+
+  const normalizedRows = normalizeRows(rows);
+  let headers = Object.keys(normalizedRows[0] ?? {});
+
+  if (headers.includes("change_pct_formatted")) {
+    headers = headers.filter((header) => header !== "change_pct");
+  }
+
+  return (
+    <div className="mt-6 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      <div className="max-h-96 overflow-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-left text-sm text-gray-700">
+          <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+            <tr>
+              {headers.map((header) => (
+                <th key={header} className="px-4 py-3 font-semibold">
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 bg-white">
+            {normalizedRows.map((row, rowIndex) => (
+              <tr key={`row-${rowIndex}`} className="hover:bg-gray-50">
+                {headers.map((header) => {
+                  const value = row[header];
+                  const displayValue = value === null || value === undefined ? "" : String(value);
+                  return (
+                    <td key={`${rowIndex}-${header}`} className="px-4 py-2">
+                      {displayValue}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default TableRenderer;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,28 @@
-import dynamic from 'next/dynamic';
-
 "use client";
 
 import { ChatKit, useChatKit } from "@openai/chatkit-react";
+import { useEffect, useMemo, useState } from "react";
+import InsightPanel, { InsightPanelData } from "./components/InsightPanel";
+
+type MessageContentBlock = {
+  type?: string;
+  name?: string;
+  text?: string;
+  data?: unknown;
+};
+
+type ChatKitMessage = {
+  content?: MessageContentBlock[];
+  metadata?: Record<string, any> | null;
+  role?: string;
+};
 
 export default function ChatPage() {
-  const { control, error } = useChatKit({
+  const [insight, setInsight] = useState<InsightPanelData | null>(null);
+
+  const { control, error, messages } = useChatKit({
     api: {
-      async getClientSecret(existing) {
-        // If you store/refresh sessions, handle `existing` here
+      async getClientSecret(_existing) {
         const res = await fetch("/api/chatkit/session", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -20,12 +34,83 @@ export default function ChatPage() {
     },
   });
 
+  const chatMessages = useMemo(() => (Array.isArray(messages) ? (messages as ChatKitMessage[]) : []), [messages]);
+
+  useEffect(() => {
+    if (!chatMessages.length) return;
+    const latest = chatMessages[chatMessages.length - 1];
+    const contentBlocks = Array.isArray(latest?.content) ? latest.content : [];
+
+    if ((latest?.role && latest.role !== "assistant") || (contentBlocks.length === 0 && !latest?.metadata)) {
+      return;
+    }
+
+    const chartBlock = contentBlocks.find((block) => block?.name === "chart");
+    const tableBlock = contentBlocks.find((block) => block?.name === "table");
+    const textBlock = contentBlocks.find((block) => typeof block?.text === "string");
+    const followupsBlock = contentBlocks.find((block) => block?.name === "followups");
+
+    const chartData =
+      chartBlock && typeof chartBlock === "object" && chartBlock.data && typeof chartBlock.data === "object"
+        ? (chartBlock.data as InsightPanelData["chart"])
+        : null;
+    const tableData =
+      tableBlock && typeof tableBlock === "object" && Array.isArray(tableBlock.data as unknown[])
+        ? (tableBlock.data as InsightPanelData["table"])
+        : null;
+    const followupsData =
+      followupsBlock && followupsBlock.data && typeof followupsBlock.data === "object" &&
+      Array.isArray((followupsBlock.data as any)?.suggestions)
+        ? ((followupsBlock.data as any).suggestions as string[])
+        : null;
+
+    const metadata = latest?.metadata ?? {};
+    const warnings = Array.isArray(metadata?.warnings) ? metadata.warnings : [];
+    const summaryText =
+      typeof textBlock?.text === "string"
+        ? textBlock.text
+        : typeof metadata?.answer === "string"
+          ? metadata.answer
+          : "";
+    const chartFromMetadata = metadata?.chart && typeof metadata.chart === "object" ? metadata.chart : null;
+    const tableFromMetadata = Array.isArray(metadata?.table) ? metadata.table : null;
+
+    const resolvedChart = (chartData as InsightPanelData["chart"]) ?? (chartFromMetadata as InsightPanelData["chart"]) ?? null;
+    const resolvedTable = (tableData as InsightPanelData["table"]) ?? (tableFromMetadata as InsightPanelData["table"]) ?? null;
+
+    const insightPayload: InsightPanelData = {
+      summary: summaryText,
+      chart: resolvedChart,
+      table: resolvedTable,
+      sql: metadata?.sql ?? null,
+      plan: metadata?.plan ?? null,
+      lineage: metadata?.lineage ?? null,
+      warnings,
+      status: metadata?.status ?? null,
+      followups: followupsData,
+      chips: metadata?.chips ?? null,
+      nqlStatus: metadata?.nql_status ?? null,
+    };
+
+    setInsight(insightPayload);
+  }, [chatMessages]);
+
   return (
-    <div className="w-full max-w-3xl h-[600px]">
-      {error ? (
-        <div className="text-red-500 text-sm p-2">Chat init failed: {String(error)}</div>
-      ) : null}
-      <ChatKit control={control} className="h-full w-full" />
+    <div className="grid h-screen grid-cols-1 gap-4 bg-gray-50 p-4 md:grid-cols-2">
+      <div id="chat-pane" className="flex h-full flex-col">
+        <div className="flex-1 overflow-hidden rounded-xl bg-white shadow-sm">
+          {error ? (
+            <div className="flex h-full items-center justify-center p-4 text-sm text-red-600">
+              Chat init failed: {String(error)}
+            </div>
+          ) : (
+            <ChatKit control={control} className="h-full w-full" />
+          )}
+        </div>
+      </div>
+      <div id="insight-pane" className="flex h-full flex-col">
+        <InsightPanel data={insight} />
+      </div>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@openai/chatkit-react": "^0.0.0",
+        "chart.js": "^4.5.0",
         "next": "^14.2.33",
         "react": "^18.3.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
@@ -92,6 +94,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "14.2.33",
@@ -576,6 +584,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -1476,6 +1496,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@openai/chatkit-react": "^0.0.0",
+    "chart.js": "^4.5.0",
     "next": "^14.2.33",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- restructure the chat page into a two-column experience that pairs the existing ChatKit UI with an insight pane
- implement an InsightPanel component that surfaces summaries, warnings, follow ups, chart, table, and SQL/plan/lineage details
- add reusable chart and table renderer components backed by react-chartjs-2 and update dependencies to support them

## Testing
- not run (requires existing ESLint configuration before `npm run lint` can execute)


------
https://chatgpt.com/codex/tasks/task_e_68e5ae65ce88832e87b08c5c4eeef64b